### PR TITLE
Introduce Build entity and move publish profiles to BuildTarget

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_build_model_refactor.py
+++ b/alembic/versions/a1b2c3d4e5f6_build_model_refactor.py
@@ -1,0 +1,100 @@
+"""build model refactor: add Build entity, move publish profiles to BuildTarget
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9ee7c83a755f
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '9ee7c83a755f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add name column to build_targets (nullable first for backfill)
+    with op.batch_alter_table('build_targets') as batch_op:
+        batch_op.add_column(sa.Column('name', sa.String(), nullable=True))
+
+    # 2. Backfill name with empty string
+    op.execute("UPDATE build_targets SET name = ''")
+
+    # 3. Make name non-nullable (batch required for SQLite)
+    with op.batch_alter_table('build_targets') as batch_op:
+        batch_op.alter_column('name', nullable=False, server_default='')
+
+    # 4. Create builds table
+    op.create_table(
+        'builds',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('build_target_id', sa.Integer(), nullable=False),
+        sa.Column('version', sa.String(), nullable=False),
+        sa.Column('output_path', sa.String(), nullable=False),
+        sa.Column('status', sa.Enum('in_progress', 'success', 'failed', name='buildstatusenum'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('vcs_commit', sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(['build_target_id'], ['build_targets.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    # 5. Add build_target_id to publish_profile (nullable first for backfill)
+    with op.batch_alter_table('publish_profile') as batch_op:
+        batch_op.add_column(sa.Column('build_target_id', sa.Integer(), nullable=True))
+
+    # 6. Backfill build_target_id: assign each profile to the first build_target of its project
+    op.execute("""
+        UPDATE publish_profile
+        SET build_target_id = (
+            SELECT bt.id
+            FROM build_targets bt
+            WHERE bt.project_id = publish_profile.project_id
+            ORDER BY bt.id ASC
+            LIMIT 1
+        )
+    """)
+
+    # 7. Make build_target_id non-nullable and create FK; drop old columns
+    with op.batch_alter_table('publish_profile') as batch_op:
+        batch_op.alter_column('build_target_id', nullable=False)
+        batch_op.create_foreign_key(
+            'fk_publish_profile_build_target_id',
+            'build_targets',
+            ['build_target_id'], ['id']
+        )
+        batch_op.drop_column('build_id')
+        batch_op.drop_column('project_id')
+
+
+def downgrade() -> None:
+    # Restore project_id and build_id as nullable
+    with op.batch_alter_table('publish_profile') as batch_op:
+        batch_op.add_column(sa.Column('project_id', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('build_id', sa.String(), nullable=True))
+
+    # Backfill project_id from build_target
+    op.execute("""
+        UPDATE publish_profile
+        SET project_id = (
+            SELECT bt.project_id
+            FROM build_targets bt
+            WHERE bt.id = publish_profile.build_target_id
+        )
+    """)
+
+    # Drop build_target_id FK and column
+    with op.batch_alter_table('publish_profile') as batch_op:
+        batch_op.drop_constraint('fk_publish_profile_build_target_id', type_='foreignkey')
+        batch_op.drop_column('build_target_id')
+
+    # Drop builds table
+    op.drop_table('builds')
+
+    # Drop build_targets.name
+    with op.batch_alter_table('build_targets') as batch_op:
+        batch_op.drop_column('name')

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from build_bridge.log import setup_logging
 from build_bridge.utils.paths import get_resource_path
 
 from build_bridge.database import SessionFactory, create_or_update_db
-from build_bridge.models import BuildTarget, Project
+from build_bridge.models import Project
 from build_bridge.views.widgets.build_targets_widget import BuildTargetListWidget
 from build_bridge.views.widgets.publish_profile_read_widgets import (
     PublishProfileListWidget,
@@ -33,16 +33,7 @@ class BuildBridgeWindow(QMainWindow):
         self.setMinimumSize(760, 520)
 
         self.session = SessionFactory()
-
-        # One day, support multiproject. For now, only one
         self.project = self.session.query(Project).first()
-
-        # Single build target setup too.
-        self.build_target = (
-            self.session.query(BuildTarget).order_by(BuildTarget.id.desc()).first()
-        )
-
-        self.vcs_client = None
 
         self.build_list_widget = None
         self.init_ui()
@@ -63,12 +54,9 @@ class BuildBridgeWindow(QMainWindow):
         main_layout.setContentsMargins(24, 20, 24, 24)
         main_layout.setSpacing(18)
 
-
         # Build Target Section
-        build_target_id = self.build_target.id if self.build_target else None
-        build_target_widget = BuildTargetListWidget(
-            build_target_id=build_target_id, parent=self
-        )
+        project_id = self.project.id if self.project else None
+        build_target_widget = BuildTargetListWidget(project_id=project_id, parent=self)
         build_target_widget.build_ready_signal.connect(self.refresh_builds)
         main_layout.addWidget(build_target_widget)
 
@@ -91,14 +79,6 @@ class BuildBridgeWindow(QMainWindow):
         builds_layout.addWidget(heading_row)
 
         self.build_list_widget = PublishProfileListWidget()
-
-        if self.project:
-            builds_dir = self.project.builds_path
-        else:
-            builds_dir = None
-
-        self.build_list_widget.refresh_builds(builds_dir)
-
         self.build_list_widget.setMinimumHeight(100)
         builds_layout.addWidget(self.build_list_widget)
 
@@ -113,49 +93,27 @@ class BuildBridgeWindow(QMainWindow):
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self)
-        # Connect signal BEFORE exec()
         dialog.monitored_dir_changed_signal.connect(self.refresh_builds)
         result = dialog.exec()
 
         if result == QDialog.DialogCode.Accepted:
             logging.info("Settings accepted, refreshing main window project data...")
             try:
-                # Re-query or refresh the project in the main window's session
                 if self.project:
                     self.session.refresh(self.project)
-                    logging.info(
-                        f"Refreshed project '{self.project.name}' in main window session."
-                    )
-                    self.build_list_widget.refresh_builds(self.project.builds_path)
-
+                    logging.info(f"Refreshed project '{self.project.name}' in main window session.")
                 else:
-                    # If no project existed initially, try loading one now
                     self.project = self.session.query(Project).first()
                     if self.project:
-                        logging.info(
-                            f"Loaded newly created project '{self.project.name}' into main window."
-                        )
-                        self.build_list_widget.refresh_builds(self.project.builds_path)
-
+                        logging.info(f"Loaded newly created project '{self.project.name}' into main window.")
+                self.build_list_widget.refresh_builds()
             except Exception as e:
                 logging.info(f"Error refreshing project in main window after settings: {e}")
-
-    def get_selected_branch(self):
-        selected_items = self.branch_list.selectedItems()
-        if not selected_items:
-            return None
-        return selected_items[0].text()
-
-    def focusInEvent(self, a0):
-        return super().focusInEvent(a0)
 
     def refresh_builds(self):
         self.build_list_widget.refresh_builds()
 
     def closeEvent(self, event):
-        if self.vcs_client:
-            self.vcs_client._disconnect()
-
         super().closeEvent(event)
 
 

--- a/build_bridge/core/preflight.py
+++ b/build_bridge/core/preflight.py
@@ -156,11 +156,15 @@ def validate_build_preflight(build_target, release_name: str) -> PreflightResult
     else:
         result.error("Build version", "Enter a release/build version.")
 
-    if _truthy(archive_directory) and _truthy(getattr(project, "name", None)) and _truthy(
-        release_name
-    ):
-        output_dir = Path(str(archive_directory)) / str(project.name) / str(release_name)
-        if output_dir.exists():
+    if _truthy(release_name) and hasattr(build_target, "builds_path"):
+        try:
+            output_dir = build_target.builds_path / str(release_name)
+        except Exception:
+            output_dir = None
+
+        if output_dir is None:
+            result.warning("Output folder", "Could not determine output path.")
+        elif output_dir.exists():
             result.warning(
                 "Output folder",
                 f"Build folder already exists and will require overwrite confirmation: {output_dir}",

--- a/build_bridge/core/publisher/base_publisher.py
+++ b/build_bridge/core/publisher/base_publisher.py
@@ -14,5 +14,5 @@ class BasePublisher(ABC):
 
 
     @abstractmethod
-    def publish(self, parent=None):
+    def publish(self, content_dir: str, version: str = ""):
         """Execute the publishing process."""

--- a/build_bridge/core/publisher/itch/itch_publisher.py
+++ b/build_bridge/core/publisher/itch/itch_publisher.py
@@ -99,15 +99,15 @@ class ItchPublisher(BasePublisher):
                 "Butler not found. Please set it in Settings."
             )
 
-    def publish(self, content_dir: str):
+    def publish(self, content_dir: str, version: str = ""):
         """
         Prepares the butler command and launches the ItchUploadDialog to execute it.
 
         Args:
             content_dir: Path to the directory containing the built game files.
-            build_id: The version or identifier for this build (e.g., "1.0.0").
+            version: The version string for this build (e.g., "1.0.0").
         """
-        logging.info(f"Preparing Itch.io publish for build: {self.publish_profile.build_id}")
+        logging.info(f"Preparing Itch.io publish for build: {version}")
 
         # --- Construct Butler Command Arguments ---
         # Note: command executable is passed separately to QProcess
@@ -119,11 +119,12 @@ class ItchPublisher(BasePublisher):
             str(Path(content_dir).resolve()),  # Ensure absolute path
             f"{itch_target}:{self.publish_profile.itch_channel_name}",
             "--userversion",
-            self.publish_profile.build_id,
+            version,
         ]
 
         logging.info(f"Command: {butler_exe} {' '.join(arguments)}")
         logging.info(f"Target: {itch_target}")
+        project_name = self.publish_profile.project.name if self.publish_profile.project else ""
         # --- Launch Dialog ---
         try:
             dialog = GenericUploadDialog(
@@ -132,10 +133,10 @@ class ItchPublisher(BasePublisher):
                     "BUTLER_API_KEY": f"{self.publish_profile.itch_config.api_key}",
                     "BUTLER_NO_TTY": "1",
                 },
-                title=self.publish_profile.project.name,
+                title=project_name,
                 arguments=arguments,
                 display_info={  # Pass info for display in the dialog
-                    "build_id": self.publish_profile.build_id,
+                    "build_id": version,
                     "target": itch_target,
                     "content_dir": content_dir,
                 },

--- a/build_bridge/core/publisher/steam/steam_publisher.py
+++ b/build_bridge/core/publisher/steam/steam_publisher.py
@@ -64,7 +64,7 @@ class SteamPublisher(BasePublisher):
         if not steam_config.steamcmd_path:
             raise InvalidConfigurationError("SteamCMD not set in Steam Settings.")
 
-    def publish(self, content_dir):
+    def publish(self, content_dir: str, version: str = ""):
         """Start the Steam publishing process."""
 
         self.validate_publish_profile()
@@ -93,11 +93,12 @@ class SteamPublisher(BasePublisher):
             else self.publish_profile.app_id
         )
         display_info = {
-            "Build ID": self.publish_profile.build_id,
+            "Build ID": version,
             "App ID": str(target_app_id),
             "Target": f"Steam ({self.publish_profile.steam_config.username})",
         }
-        title = f"Steam Upload: {self.publish_profile.project.name} - {self.publish_profile.build_id}"
+        project_name = self.publish_profile.project.name if self.publish_profile.project else ""
+        title = f"Steam Upload: {project_name} - {version}"
 
         # Proceed with publishing
         dialog = GenericUploadDialog(

--- a/build_bridge/models.py
+++ b/build_bridge/models.py
@@ -1,9 +1,10 @@
 import logging
 import enum
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from sqlalchemy import JSON, Boolean, Column, Enum, ForeignKey, Integer, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship, validates, Mapped, mapped_column
 import keyring
 
@@ -31,6 +32,12 @@ class StoreEnum(str, enum.Enum):
     steam = "Steam"
 
 
+class BuildStatusEnum(str, enum.Enum):
+    in_progress = "in_progress"
+    success = "success"
+    failed = "failed"
+
+
 class Project(Base):
     __tablename__ = "project"
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -42,16 +49,9 @@ class Project(Base):
     build_targets = relationship(
         "BuildTarget", back_populates="project", cascade="all, delete-orphan"
     )
-    publish_profiles = relationship(
-        "PublishProfile", back_populates="project", cascade="all, delete-orphan"
-    )
 
     def is_valid(self):
         return bool(self.name) and bool(self.source_dir) and bool(self.archive_directory)
-
-    @property
-    def builds_path(self):
-        return Path(str(self.archive_directory)) / self.name
 
 
 class BuildTarget(Base):
@@ -61,6 +61,8 @@ class BuildTarget(Base):
 
     project_id = Column(Integer, ForeignKey("project.id"), nullable=False)
     project = relationship("Project", back_populates="build_targets")
+
+    name = Column(String, nullable=False, default="")
 
     unreal_engine_base_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
@@ -80,8 +82,30 @@ class BuildTarget(Base):
 
     auto_sync_branch = Column(Boolean, nullable=False, default=False)
 
+    builds = relationship("Build", back_populates="build_target", cascade="all, delete-orphan")
+    publish_profiles = relationship("PublishProfile", back_populates="build_target", cascade="all, delete-orphan")
+
+    @property
+    def builds_path(self) -> Path:
+        return Path(str(self.project.archive_directory)) / self.project.name / self.name
+
     def __repr__(self):
-        return f"{self.project.name} - {self.target_platform.value}"
+        label = self.name or self.project.name
+        return f"{label} ({self.target_platform.value})"
+
+
+class Build(Base):
+    __tablename__ = "builds"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    build_target_id = Column(Integer, ForeignKey("build_targets.id"), nullable=False)
+    build_target = relationship("BuildTarget", back_populates="builds")
+
+    version = Column(String, nullable=False)
+    output_path = Column(String, nullable=False)
+    status = Column(Enum(BuildStatusEnum), nullable=False, default=BuildStatusEnum.in_progress)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    vcs_commit = Column(String, nullable=True)
 
 
 class PublishProfile(Base):
@@ -90,13 +114,16 @@ class PublishProfile(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     store_type = Column(Enum(StoreEnum), nullable=False)
 
-    project_id = Column(Integer, ForeignKey("project.id"), nullable=False)
-    project = relationship("Project", back_populates="publish_profiles")
+    build_target_id = Column(Integer, ForeignKey("build_targets.id"), nullable=False)
+    build_target = relationship("BuildTarget", back_populates="publish_profiles")
 
-    build_id = Column(String, nullable=False)
     description = Column(String, nullable=True)
 
     __mapper_args__ = {"polymorphic_on": store_type, "polymorphic_identity": None}
+
+    @property
+    def project(self):
+        return self.build_target.project if self.build_target else None
 
 
 class SteamPublishProfile(PublishProfile):
@@ -134,9 +161,8 @@ class SteamPublishProfile(PublishProfile):
 
     @property
     def builder_path(self):
-        """This is built dynamically based on project"""
-        if self.project:
-            return str(Path(self.project.builds_path) / "Steam")
+        if self.build_target:
+            return str(self.build_target.builds_path / "Steam")
 
 
 class SteamConfig(Base):

--- a/build_bridge/tests/test_build_model.py
+++ b/build_bridge/tests/test_build_model.py
@@ -1,0 +1,119 @@
+import os
+import pytest
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from build_bridge.database import Base
+from build_bridge.models import (
+    Build,
+    BuildStatusEnum,
+    BuildTarget,
+    BuildTargetPlatformEnum,
+    BuildTypeEnum,
+    Project,
+)
+
+
+@pytest.fixture
+def engine(tmp_path):
+    db_path = tmp_path / "test.db"
+    eng = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(eng)
+    yield eng
+    Base.metadata.drop_all(eng)
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as sess:
+        project = Project(
+            name="TestGame",
+            source_dir="/src",
+            archive_directory="/builds",
+        )
+        sess.add(project)
+        sess.flush()
+
+        bt = BuildTarget(
+            project_id=project.id,
+            name="Main",
+            build_type=BuildTypeEnum.prod,
+            target_platform=BuildTargetPlatformEnum.win_64,
+        )
+        sess.add(bt)
+        sess.commit()
+        yield sess
+
+
+class TestBuildModel:
+    def test_build_creation_default_status(self, session):
+        bt = session.query(BuildTarget).first()
+        build = Build(
+            build_target_id=bt.id,
+            version="1.0.0",
+            output_path="/builds/TestGame/Main/1.0.0",
+        )
+        session.add(build)
+        session.commit()
+
+        fetched = session.get(Build, build.id)
+        assert fetched is not None
+        assert fetched.version == "1.0.0"
+        assert fetched.status == BuildStatusEnum.in_progress
+        assert fetched.created_at is not None
+
+    def test_build_status_transitions(self, session):
+        bt = session.query(BuildTarget).first()
+        build = Build(
+            build_target_id=bt.id,
+            version="1.1.0",
+            output_path="/builds/TestGame/Main/1.1.0",
+        )
+        session.add(build)
+        session.commit()
+
+        build.status = BuildStatusEnum.success
+        session.commit()
+        assert session.get(Build, build.id).status == BuildStatusEnum.success
+
+        build.status = BuildStatusEnum.failed
+        session.commit()
+        assert session.get(Build, build.id).status == BuildStatusEnum.failed
+
+    def test_cascade_delete_builds_with_target(self, session):
+        bt = session.query(BuildTarget).first()
+        build = Build(
+            build_target_id=bt.id,
+            version="2.0.0",
+            output_path="/builds/TestGame/Main/2.0.0",
+        )
+        session.add(build)
+        session.commit()
+        build_id = build.id
+
+        session.delete(bt)
+        session.commit()
+
+        assert session.get(Build, build_id) is None
+
+    def test_builds_path_structure(self, tmp_path):
+        project = Project(
+            name="MyGame",
+            source_dir=str(tmp_path),
+            archive_directory=str(tmp_path / "Builds"),
+        )
+        bt = BuildTarget(
+            project=project,
+            name="Demo",
+            build_type=BuildTypeEnum.prod,
+            target_platform=BuildTargetPlatformEnum.win_64,
+        )
+
+        expected = Path(str(tmp_path / "Builds")) / "MyGame" / "Demo"
+        assert bt.builds_path == expected
+
+    def test_build_target_name_in_repr(self, session):
+        bt = session.query(BuildTarget).first()
+        assert "Main" in repr(bt)
+        assert "Win64" in repr(bt)

--- a/build_bridge/tests/test_preflight.py
+++ b/build_bridge/tests/test_preflight.py
@@ -28,6 +28,8 @@ def _make_build_target(tmp_path):
 
     bt = MagicMock()
     bt.project = project
+    bt.name = "Main"
+    bt.builds_path = tmp_path / "Builds" / "MyGame" / "Main"
     bt.unreal_engine_base_path = str(engine_dir)
     bt.target = str(target_file)
     bt.build_type = MagicMock(value="Shipping")
@@ -62,7 +64,7 @@ class TestBuildPreflight:
 
     def test_existing_output_folder_is_warning_not_error(self, tmp_path):
         bt = _make_build_target(tmp_path)
-        existing = tmp_path / "Builds" / "MyGame" / "1.0.0"
+        existing = tmp_path / "Builds" / "MyGame" / "Main" / "1.0.0"
         existing.mkdir(parents=True)
         result = validate_build_preflight(bt, "1.0.0")
         warning_labels = [i.label for i in result.issues if i.severity == "warning"]

--- a/build_bridge/views/dialogs/build_dialog.py
+++ b/build_bridge/views/dialogs/build_dialog.py
@@ -22,6 +22,7 @@ from build_bridge.utils.paths import get_resource_path
 
 class BuildWindowDialog(QDialog):
     build_ready_signal = pyqtSignal()
+    build_failed_signal = pyqtSignal()
 
     def __init__(self, builder: UnrealBuilder, parent=None):
         super().__init__(parent)
@@ -155,6 +156,7 @@ class BuildWindowDialog(QDialog):
     def reset_after_cancel(self):
         self.build_in_progress = False
         self._cleanup_process_state()
+        self.build_failed_signal.emit()
         self._set_action_button("Retry Build", self.start_build)
         self.action_button.setEnabled(True)
 
@@ -205,6 +207,7 @@ class BuildWindowDialog(QDialog):
         else:
             self.append_output(f"\nERROR: BUILD FAILED (Exit code: {exit_code})")
             logging.info(f"Build failed with exit code {exit_code}")
+            self.build_failed_signal.emit()
             self._set_action_button("Close", self.close)
 
         self._cleanup_process_state()

--- a/build_bridge/views/dialogs/build_target_setup_dialog.py
+++ b/build_bridge/views/dialogs/build_target_setup_dialog.py
@@ -160,6 +160,10 @@ class BuildTargetSetupDialog(QDialog):
         project_form = QFormLayout(self.project_form_widget)
         project_form.setContentsMargins(0, 0, 0, 0)  # Remove margins if needed
 
+        self.target_name_edit = QLineEdit()
+        self.target_name_edit.setPlaceholderText("e.g. Main App, Demo, QA")
+        project_form.addRow("Target Name:", self.target_name_edit)
+
         self.project_combo = QComboBox()
         self.source_edit = QLineEdit()
         browse_button = QPushButton("Browse")
@@ -521,8 +525,13 @@ class BuildTargetSetupDialog(QDialog):
             self.bt_ue_path_edit.setText(directory)
 
     def initialize_form(self):
-        # --- Refresh Project List and set visibility ---        
+        # --- Refresh Project List and set visibility ---
         self._refresh_project_list()
+
+        # Populate Target Name
+        self.target_name_edit.setText(
+            self.build_target.name if self.build_target and self.build_target.name else ""
+        )
 
         # --- Initialize Page 2 fields ---
         self.build_type_combo.clear()
@@ -631,6 +640,8 @@ class BuildTargetSetupDialog(QDialog):
             else:
                 # Ensure existing build_target is associated with the selected project
                 self.build_target.project = self.session_project
+
+            self.build_target.name = self.target_name_edit.text().strip()
 
             self.build_target.build_type = BuildTypeEnum(
                 self.build_type_combo.currentText()

--- a/build_bridge/views/dialogs/publish_profile_dialog.py
+++ b/build_bridge/views/dialogs/publish_profile_dialog.py
@@ -42,7 +42,10 @@ class PublishProfileDialog(QDialog):
 
         # Set window properties
         store_label = getattr(self.publish_profile.store_type, "value", str(self.publish_profile.store_type))
-        self.setWindowTitle(f"{store_label} Profile — {self.publish_profile.build_id}")
+        target_name = ""
+        if getattr(self.publish_profile, "build_target", None):
+            target_name = self.publish_profile.build_target.name or ""
+        self.setWindowTitle(f"{store_label} Profile — {target_name}")
 
         self.setMinimumWidth(650)
         self.setMinimumHeight(500)

--- a/build_bridge/views/dialogs/publish_profile_manager_dialog.py
+++ b/build_bridge/views/dialogs/publish_profile_manager_dialog.py
@@ -12,8 +12,8 @@ from PyQt6.QtWidgets import (
 )
 
 from build_bridge.models import (
+    BuildTarget,
     ItchPublishProfile,
-    Project,
     PublishProfile,
     SteamPublishProfile,
     StoreEnum,
@@ -35,20 +35,24 @@ class PublishProfileManagerDialog(QDialog):
     def __init__(
         self,
         session,
-        build_id: str,
+        build_target_id: int,
         store_type: StoreEnum,
         selected_profile_id: int | None = None,
         parent=None,
     ):
         super().__init__(parent)
         self.session = session
-        self.build_id = build_id
+        self.build_target_id = build_target_id
         self.store_type = store_type
         self.selected_profile_id = selected_profile_id
+
+        build_target = session.get(BuildTarget, build_target_id)
+        target_label = build_target.name if build_target and build_target.name else f"Target #{build_target_id}"
 
         self.setWindowTitle(f"{store_type.value} Publish Profiles")
         self.setMinimumSize(560, 360)
 
+        self._target_label = target_label
         self._init_ui()
         self._refresh_profiles(selected_profile_id)
 
@@ -56,7 +60,7 @@ class PublishProfileManagerDialog(QDialog):
         main_layout = QVBoxLayout(self)
         main_layout.setSpacing(12)
 
-        header = QLabel(f"{self.store_type.value} profiles for {self.build_id}")
+        header = QLabel(f"{self.store_type.value} profiles for {self._target_label}")
         header.setObjectName("sectionTitle")
         main_layout.addWidget(header)
 
@@ -111,7 +115,7 @@ class PublishProfileManagerDialog(QDialog):
     def _refresh_profiles(self, selected_profile_id=None):
         profiles = (
             self.session.query(self._profile_model())
-            .filter_by(build_id=self.build_id)
+            .filter_by(build_target_id=self.build_target_id)
             .order_by(PublishProfile.id.asc())
             .all()
         )
@@ -150,10 +154,8 @@ class PublishProfileManagerDialog(QDialog):
         return self.session.get(self._profile_model(), profile_id)
 
     def _make_profile_instance(self):
-        project = self.session.query(Project).one_or_none()
         return self._profile_model()(
-            project_id=project.id if project else None,
-            build_id=self.build_id,
+            build_target_id=self.build_target_id,
             store_type=self.store_type,
             description="New Profile",
         )
@@ -185,21 +187,14 @@ class PublishProfileManagerDialog(QDialog):
 
         current_name = self._profile_label(profile)
         new_name, accepted = QInputDialog.getText(
-            self,
-            "Rename Profile",
-            "Profile name:",
-            text=current_name,
+            self, "Rename Profile", "Profile name:", text=current_name,
         )
         if not accepted:
             return
 
         new_name = new_name.strip()
         if not new_name:
-            QMessageBox.warning(
-                self,
-                "Rename Profile",
-                "Profile name cannot be empty.",
-            )
+            QMessageBox.warning(self, "Rename Profile", "Profile name cannot be empty.")
             return
 
         profile.description = new_name
@@ -215,8 +210,7 @@ class PublishProfileManagerDialog(QDialog):
             return
 
         response = QMessageBox.question(
-            self,
-            "Delete Profile",
+            self, "Delete Profile",
             f"Delete publish profile '{self._profile_label(profile)}'?",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.No,

--- a/build_bridge/views/dialogs/settings_dialog.py
+++ b/build_bridge/views/dialogs/settings_dialog.py
@@ -342,12 +342,12 @@ class SettingsDialog(QDialog):
             self.session.flush()
 
             if self._initial_archive_dir != self.project.archive_directory:
-                self.monitored_dir_changed_signal.emit(str(self.project.builds_path))
+                self.monitored_dir_changed_signal.emit(self.project.archive_directory)
 
             logging.info("Settings: Commit successful")
 
             logging.info(
-                f"Settings: Saving project - Name: '{self.project.name}', Source: '{self.project.source_dir}', Builds will be stored in: '{self.project.builds_path}'"
+                f"Settings: Saving project - Name: '{self.project.name}', Source: '{self.project.source_dir}', Archive dir: '{self.project.archive_directory}'"
             )
 
             if errors_occurred:

--- a/build_bridge/views/widgets/build_targets_widget.py
+++ b/build_bridge/views/widgets/build_targets_widget.py
@@ -11,7 +11,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QFrame,
     QSizePolicy,
-    QSpacerItem,
     QMessageBox,
     QDialog,
 )
@@ -26,398 +25,233 @@ from build_bridge.core.builder.unreal_builder import (
 )
 from build_bridge.core.preflight import validate_build_preflight
 from build_bridge.database import session_scope
-from build_bridge.models import BuildTarget
+from build_bridge.models import Build, BuildStatusEnum, BuildTarget
 from build_bridge.views.dialogs.build_dialog import BuildWindowDialog
 from build_bridge.views.dialogs.preflight_dialog import PreflightDialog
 from build_bridge.views.dialogs.build_target_setup_dialog import BuildTargetSetupDialog
 
 
-class BuildTargetListWidget(QWidget):
-    """Lists the available Build Targets or shows an Add button."""
+class BuildTargetRow(QWidget):
+    """A single row representing one BuildTarget with its build controls."""
 
     build_ready_signal = pyqtSignal()
 
-    def __init__(self, build_target_id: int | None, parent=None):  # Accept ID
-        super().__init__()
-        self.parent = parent
-        self.vcs_client = parent.vcs_client if parent else None
-        self._build_target_id = build_target_id  # Store the ID
+    def __init__(self, build_target_id: int, parent=None):
+        super().__init__(parent)
+        self._build_target_id = build_target_id
+        self._parent_widget = parent
 
-        outer_layout = QVBoxLayout(self)
-        outer_layout.setContentsMargins(0, 0, 0, 0)
-        outer_layout.setSpacing(10)
+        self.setObjectName("buildCard")
+        row_layout = QHBoxLayout(self)
+        row_layout.setContentsMargins(14, 10, 14, 10)
+        row_layout.setSpacing(10)
 
-        heading_label = QLabel("Build Configuration")
-        heading_label.setObjectName("sectionTitle")
-        outer_layout.addWidget(heading_label)
-
-        self.contrast_frame = QFrame()
-        self.contrast_frame.setObjectName("mainPanel")
-        self.contrast_frame.setFrameShape(QFrame.Shape.StyledPanel)
-
-        self.content_layout = QHBoxLayout(self.contrast_frame)
-        self.content_layout.setContentsMargins(14, 12, 14, 12)
-        self.content_layout.setSpacing(10)
-
-        display_name_font = QFont()
-        display_name_font.setBold(True)
+        name_font = QFont()
+        name_font.setBold(True)
         self.target_label = QLabel()
         self.target_label.setObjectName("primaryText")
-        self.target_label.setFont(display_name_font)
-        self.target_label.setSizePolicy(
-            QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred
-        )
+        self.target_label.setFont(name_font)
+        self.target_label.setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
+        row_layout.addWidget(self.target_label)
 
-        self.build_version_label = QLabel("Version")
-        self.build_version_label.setObjectName("fieldLabel")
+        row_layout.addStretch(1)
+
+        version_label = QLabel("Version")
+        version_label.setObjectName("fieldLabel")
+        row_layout.addWidget(version_label)
+
         self.build_version_input = QLineEdit("0.1")
         self.build_version_input.setFixedWidth(92)
-        self.build_version_input.setToolTip(
-            "Enter the desired version string for this build (e.g., 1.0, 0.2-beta)"
-        )
+        self.build_version_input.setToolTip("Version string for this build (e.g. 1.0, 0.2-beta)")
+        row_layout.addWidget(self.build_version_input)
 
         self.edit_button = QPushButton("Edit")
+        row_layout.addWidget(self.edit_button)
+
         self.build_button = QPushButton("Build")
         self.build_button.setObjectName("primaryButton")
+        row_layout.addWidget(self.build_button)
 
-        # Widget for the "No Build Target" state ---
-        self.add_button = QPushButton("Add Build Target")
-        self.add_button.setObjectName("primaryButton")
-
-        self.content_layout.addWidget(self.target_label)
-
-        self.content_layout.addStretch(1)
-
-        self.content_layout.addWidget(self.build_version_label)
-        self.content_layout.addWidget(self.build_version_input)
-        self.content_layout.addWidget(self.edit_button)
-        self.content_layout.addWidget(self.build_button)
-
-        self.content_layout.addWidget(self.add_button)
-
-        # Spacers for centering the 'Add' button when it's alone
-        self.left_spacer = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
-        self.right_spacer = QSpacerItem(
-            40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum
-        )
-
-        # Connect signals
         self.edit_button.clicked.connect(self.open_edit_dialog)
         self.build_button.clicked.connect(self.trigger_build)
-        self.add_button.clicked.connect(self.open_edit_dialog)
 
-        outer_layout.addWidget(self.contrast_frame)
+        self._refresh_label()
 
-        # Load initial state and set visibility correctly
-        self._load_and_display_target()
-
-    def _set_widgets_visibility(self, show_target_details: bool):
-        """Helper to show/hide widgets based on target presence."""
-        # --- Widgets for existing target ---
-        self.target_label.setVisible(show_target_details)
-        self.build_version_label.setVisible(show_target_details)  # Show/hide new label
-        self.build_version_input.setVisible(show_target_details)
-        self.edit_button.setVisible(show_target_details)
-        self.build_button.setVisible(show_target_details)
-        # The stretch is part of the layout, always present but effective only
-        # when buttons are visible and need pushing.
-
-        # --- Widget for adding a new target ---
-        self.add_button.setVisible(not show_target_details)
-
-        # --- Manage Spacers for Centering 'Add' Button ---
-        # Remove existing spacers first if they are there
-        if self.content_layout.itemAt(0) == self.left_spacer:
-            self.content_layout.removeItem(self.left_spacer)
-        if (
-            self.content_layout.itemAt(self.content_layout.count() - 1)
-            == self.right_spacer
-        ):
-            self.content_layout.removeItem(self.right_spacer)
-
-        # Add spacers ONLY if the 'Add' button is the only visible element
-        if not show_target_details:
-            # Insert spacer at the beginning
-            self.content_layout.insertItem(0, self.left_spacer)
-            # Add spacer at the end (after the add_button which is now the last widget)
-            self.content_layout.addItem(self.right_spacer)
-
-        # Invalidate layout to reflect spacer changes
-        self.content_layout.invalidate()
-        self.content_layout.activate()
-
-    def _load_and_display_target(self):
-        """Fetches the BuildTarget by ID and updates the UI visibility and content."""
-        if self._build_target_id is None:
-            self._set_widgets_visibility(False)  # Show only Add button centered
-            return
-
+    def _refresh_label(self):
         try:
             with session_scope() as session:
-                # Re-fetch the target to ensure it's in the current session
-                build_target = session.get(BuildTarget, self._build_target_id)
-
-                if build_target:
-
-                    display_text = build_target.__repr__()
-                    self.target_label.setText(display_text)
-                    self.target_label.setToolTip(
-                        f"Currently configured build target:\n{display_text}"
-                    )
-                    self.build_button.setEnabled(True)
-                    self._set_widgets_visibility(True)
-                else:
-                    logging.info(f"BuildTarget with ID {self._build_target_id} not found.")
-                    self._build_target_id = None  # Reset ID if not found
-                    self._set_widgets_visibility(False)  # Show only Add button centered
+                bt = session.get(BuildTarget, self._build_target_id)
+                if bt:
+                    self.target_label.setText(repr(bt))
+                    self.target_label.setToolTip(repr(bt))
         except Exception as e:
-            logging.info(
-                f"Error loading BuildTarget ID {self._build_target_id}: {e}",
-                exc_info=True,
-            )
-            self._build_target_id = None  # Reset on error
-            self._set_widgets_visibility(False)  # Show only Add button centered
+            logging.info(f"Error refreshing build target label: {e}")
 
     def open_edit_dialog(self):
         dialog = BuildTargetSetupDialog(build_target_id=self._build_target_id)
-        try:
-            pass  # Disconnect if needed
-        except TypeError:
-            pass  # Signal not connected
-        dialog.build_target_created.connect(self.on_new_build_target)
+        dialog.build_target_created.connect(self._on_target_updated)
         dialog.exec()
 
-    def on_new_build_target(self, new_build_target_id: int):
-        logging.info(f"Received new/updated build target ID: {new_build_target_id}")
-        self._build_target_id = new_build_target_id
-        self._load_and_display_target()  # Refresh UI
+    def _on_target_updated(self, _build_target_id: int):
+        self._refresh_label()
 
     def trigger_build(self):
-        if self._build_target_id is None:
-            QMessageBox.warning(self, "Error", "No build target selected.")
-            return
-
-        # Get build version from the input field
         release_name = self.build_version_input.text().strip()
         if not release_name:
-            QMessageBox.warning(
-                self,
-                "Input Error",
-                "Please enter a build version/release name.",
-            )
-            # Maybe set focus back to the input field
-            # self.build_version_input.setFocus()
+            QMessageBox.warning(self, "Input Error", "Please enter a build version/release name.")
             return
 
-        # --- Proceed with build logic using 'release_name' ---
         try:
             with session_scope() as session:
                 current_build_target = session.get(BuildTarget, self._build_target_id)
-
                 if not current_build_target:
-                    QMessageBox.critical(
-                        self,
-                        "Error",
-                        f"Build target with ID {self._build_target_id} not found in database.",
-                    )
-                    self._load_and_display_target()
+                    QMessageBox.critical(self, "Error", f"Build target ID {self._build_target_id} not found.")
                     return
 
-                # Eager load project relationship
-                if not current_build_target.project:
-                    # This assumes the relationship lazy loading works or is handled
-                    # If session.get doesn't load relationships, explicitly query/load it
-                    # For simplicity, assuming project is loaded via relationship access:
-                    try:
-                        _ = (
-                            current_build_target.project.name
-                        )  # Access attribute to trigger load
-                    except AttributeError:
-                        # Handle case where project is genuinely None after access attempt
-                        QMessageBox.critical(
-                            self,
-                            "Error",
-                            "Associated project data not found for the build target.",
-                        )
-                        return
+                # Access project to trigger lazy load
+                try:
+                    _ = current_build_target.project.name
+                except AttributeError:
+                    QMessageBox.critical(self, "Error", "Associated project data not found.")
+                    return
 
-                # Get necessary paths and names
                 builds_root = current_build_target.project.archive_directory
                 source_dir = current_build_target.project.source_dir
                 project_name = current_build_target.project.name
 
                 if not all([builds_root, source_dir, project_name]):
-                    QMessageBox.critical(
-                        self,
-                        "Configuration Error",
-                        "Project archive directory, source directory, or name is missing.",
-                    )
+                    QMessageBox.critical(self, "Configuration Error",
+                                         "Project archive directory, source directory, or name is missing.")
                     return
 
-                preflight_result = validate_build_preflight(
-                    current_build_target, release_name
-                )
+                preflight_result = validate_build_preflight(current_build_target, release_name)
                 preflight_dialog = PreflightDialog(preflight_result, parent=self)
                 if preflight_dialog.exec() != QDialog.DialogCode.Accepted:
                     return
-                
+
                 engine_base_path = current_build_target.unreal_engine_base_path
                 if not engine_base_path or not os.path.isdir(engine_base_path):
                     QMessageBox.warning(self, "Configuration Error",
-                                        "Unreal Engine base path is not configured or invalid for this specific Build Target.\n\n"
-                                        "Please use the 'Edit' button to configure it.")
-                    return # Stop the build process
-                logging.info(f"Using Unreal Engine Path from Build Target config: {engine_base_path}")
+                                        "Unreal Engine base path is not configured or invalid.\n\nPlease use 'Edit' to configure it.")
+                    return
 
                 target = current_build_target.target
-                print(f"Building conf {target}")
-
                 if not target:
                     QMessageBox.warning(self, "Configuration Error",
-                                        "No config specified (eg. DefaultGame.ini).\n\n"
-                                        "Please use the 'Edit' button to configure it.")
-                    return # Stop the build process
-                logging.info(f"Using Game Config: {target}")
+                                        "No target .cs file specified.\n\nPlease use 'Edit' to configure it.")
+                    return
 
-                project_build_dir_root = Path(builds_root) / project_name / release_name
+                project_build_dir_root = current_build_target.builds_path / release_name
 
-                # Check for existing build and overwrite confirmation
                 if project_build_dir_root.exists():
                     response = QMessageBox.question(
-                        self,
-                        "Build Conflict",
+                        self, "Build Conflict",
                         f"A build already exists for release:\n{release_name}\n\n"
-                        f"Directory:\n{project_build_dir_root}\n\n"
-                        "Do you want to proceed and overwrite it?",
+                        f"Directory:\n{project_build_dir_root}\n\nOverwrite it?",
                         QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
                         QMessageBox.StandardButton.No,
                     )
                     if response == QMessageBox.StandardButton.No:
                         return
-
                     try:
                         shutil.rmtree(project_build_dir_root)
-                        logging.info(
-                            f"Removed existing build directory: {project_build_dir_root}"
-                        )
+                        logging.info(f"Removed existing build directory: {project_build_dir_root}")
                     except Exception as e:
-                        logging.info(
-                            f"Failed to delete existing build directory: {e}",
-                            exc_info=True,
-                        )
-                        QMessageBox.critical(
-                            self,
-                            "Cleanup Error",
-                            f"Failed to delete existing build directory:\n{str(e)}",
-                        )
+                        QMessageBox.critical(self, "Cleanup Error",
+                                              f"Failed to delete existing build directory:\n{str(e)}")
                         return
-                    
+
                 maps = []
-
                 for incl_map in current_build_target.maps.keys():
-                    maps.append(self.convert_umap_path(incl_map, current_build_target.project.source_dir))
-                
-                print(f"MAPS is {maps}")
+                    maps.append(self._convert_umap_path(incl_map, source_dir))
 
-                # Prepare builder arguments
                 try:
                     target_platform_val = current_build_target.target_platform.value
                     build_type_val = current_build_target.build_type.value
                     optimize_steam = current_build_target.optimize_for_steam
                 except AttributeError as e:
-                    logging.info(f"Missing build target attribute: {e}", exc_info=True)
-                    QMessageBox.critical(
-                        self,
-                        "Configuration Error",
-                        f"Build target is missing required information (e.g., platform, type): {e}",
-                    )
+                    QMessageBox.critical(self, "Configuration Error",
+                                          f"Build target missing required information: {e}")
                     return
 
-                # Create and run the builder
                 try:
                     unreal_builder = UnrealBuilder(
                         source_dir=source_dir,
-                        # Make engine path configurable via SettingsDialog later
                         engine_path=engine_base_path,
                         target_platform=target_platform_val,
                         target_config=build_type_val,
                         target=target,
                         maps=maps,
                         output_dir=project_build_dir_root,
-                        clean=False,  # Confirm if 'clean' should be an option
+                        clean=False,
                         valve_package_pad=optimize_steam,
                     )
-                # Specific error handling for UnrealBuilder initialization
                 except ProjectFileNotFoundError as e:
-                    QMessageBox.critical(
-                        self, "Project File Error", f"Project file not found: {str(e)}"
-                    )
+                    QMessageBox.critical(self, "Project File Error", f"Project file not found: {str(e)}")
                     return
                 except EngineVersionError as e:
-                    QMessageBox.critical(
-                        self,
-                        "Engine Version Error",
-                        f"Could not determine Unreal Engine version: {str(e)}",
-                    )
+                    QMessageBox.critical(self, "Engine Version Error", str(e))
                     return
                 except UnrealEngineNotInstalledError as e:
-                    QMessageBox.critical(
-                        self,
-                        "Unreal Engine Not Found",
-                        f"Unreal Engine not found. Please check configuration.\nError: {str(e)}",
-                    )
+                    QMessageBox.critical(self, "Unreal Engine Not Found", str(e))
                     return
-                except Exception as e:  # Catch other builder init errors
-                    logging.info(
-                        f"Unexpected error creating UnrealBuilder: {e}", exc_info=True
-                    )
-                    QMessageBox.critical(
-                        self,
-                        "Build Setup Error",
-                        f"Failed to initialize the builder:\n{str(e)}",
-                    )
+                except Exception as e:
+                    QMessageBox.critical(self, "Build Setup Error", f"Failed to initialize builder:\n{str(e)}")
                     return
 
-                # Show the build progress dialog
-                logging.info(f"Starting build dialog for release '{release_name}'...")
-                dialog = BuildWindowDialog(unreal_builder, parent=self)
-                try:
-                    # dialog.build_ready_signal.disconnect(self.build_ready_signal) # If needed
-                    pass
-                except TypeError:
-                    pass
-                dialog.build_ready_signal.connect(
-                    self.build_ready_signal
-                )  # Connect signal from build dialog
-                dialog.exec()  # Show modal build dialog
+                # Create Build record
+                build_record = Build(
+                    build_target_id=self._build_target_id,
+                    version=release_name,
+                    output_path=str(project_build_dir_root),
+                    status=BuildStatusEnum.in_progress,
+                )
+                session.add(build_record)
+                session.flush()
+                build_db_id = build_record.id
+
+            logging.info(f"Starting build dialog for release '{release_name}'...")
+            dialog = BuildWindowDialog(unreal_builder, parent=self)
+            dialog.build_ready_signal.connect(lambda: self._on_build_success(build_db_id))
+            dialog.build_failed_signal.connect(lambda: self._on_build_failed(build_db_id))
+            dialog.build_ready_signal.connect(self.build_ready_signal)
+            dialog.exec()
 
         except Exception as e:
-            # Catch errors during session management or top-level logic
             logging.info(f"Error during trigger_build: {e}", exc_info=True)
-            QMessageBox.critical(
-                self,
-                "Error",
-                f"An unexpected error occurred during the build process: {e}",
-            )
+            QMessageBox.critical(self, "Error", f"An unexpected error occurred: {e}")
 
-    def convert_umap_path(self, full_path: str, project_source_dir: str) -> str:
-        # Normalize paths for consistency
+    def _on_build_success(self, build_id: int):
+        try:
+            with session_scope() as session:
+                build = session.get(Build, build_id)
+                if build:
+                    build.status = BuildStatusEnum.success
+        except Exception as e:
+            logging.info(f"Failed to update build status to success: {e}")
+
+    def _on_build_failed(self, build_id: int):
+        try:
+            with session_scope() as session:
+                build = session.get(Build, build_id)
+                if build:
+                    build.status = BuildStatusEnum.failed
+        except Exception as e:
+            logging.info(f"Failed to update build status to failed: {e}")
+
+    def _convert_umap_path(self, full_path: str, project_source_dir: str) -> str:
         full_path = os.path.normpath(full_path)
         project_source_dir = os.path.normpath(project_source_dir)
 
         if not full_path.startswith(project_source_dir):
             raise ValueError("Path is not within the project source directory")
 
-        # Get relative path from source dir, use forward slashes
         relative_path = os.path.relpath(full_path, project_source_dir).replace("\\", "/")
         parts = relative_path.split("/")
 
         if parts[0] == "Plugins":
-            # Plugins/GameFeatures/DungeonCrawler/Content/Maps/Villa/Villa.umap
             try:
-                plugin_name = parts[2]  # DungeonCrawler
+                plugin_name = parts[2]
                 content_index = parts.index("Content")
                 map_subpath = parts[content_index + 1:-1]
                 map_name = os.path.splitext(parts[-1])[0]
@@ -425,7 +259,6 @@ class BuildTargetListWidget(QWidget):
             except (IndexError, ValueError):
                 raise ValueError("Invalid plugin map path structure")
         else:
-            # Content/Maps/CoverPicMap.umap
             try:
                 if parts[0] != "Content":
                     raise ValueError("Expected path to start with 'Content'")
@@ -436,3 +269,89 @@ class BuildTargetListWidget(QWidget):
                 raise ValueError("Invalid base content path structure")
 
 
+class BuildTargetListWidget(QWidget):
+    """Lists all BuildTargets for the project, or shows an Add button."""
+
+    build_ready_signal = pyqtSignal()
+
+    def __init__(self, project_id: int | None, parent=None):
+        super().__init__()
+        self._project_id = project_id
+        self._parent = parent
+
+        outer_layout = QVBoxLayout(self)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.setSpacing(10)
+
+        heading_label = QLabel("Build Configuration")
+        heading_label.setObjectName("sectionTitle")
+        outer_layout.addWidget(heading_label)
+
+        self.targets_container = QFrame()
+        self.targets_container.setObjectName("mainPanel")
+        self.targets_container.setFrameShape(QFrame.Shape.StyledPanel)
+        self.targets_layout = QVBoxLayout(self.targets_container)
+        self.targets_layout.setContentsMargins(0, 0, 0, 0)
+        self.targets_layout.setSpacing(0)
+
+        outer_layout.addWidget(self.targets_container)
+
+        self.add_button_row = QWidget()
+        add_row_layout = QHBoxLayout(self.add_button_row)
+        add_row_layout.setContentsMargins(14, 10, 14, 10)
+        self.add_button = QPushButton("+ Add Build Target")
+        self.add_button.setObjectName("primaryButton")
+        self.add_button.clicked.connect(self._open_add_dialog)
+        add_row_layout.addStretch(1)
+        add_row_layout.addWidget(self.add_button)
+        add_row_layout.addStretch(1)
+        outer_layout.addWidget(self.add_button_row)
+
+        self._refresh_targets()
+
+    def _refresh_targets(self):
+        # Clear existing rows
+        while self.targets_layout.count():
+            child = self.targets_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
+        if self._project_id is None:
+            self.targets_container.setVisible(False)
+            return
+
+        try:
+            with session_scope() as session:
+                targets = (
+                    session.query(BuildTarget)
+                    .filter_by(project_id=self._project_id)
+                    .order_by(BuildTarget.id.asc())
+                    .all()
+                )
+                target_ids = [t.id for t in targets]
+
+            if target_ids:
+                self.targets_container.setVisible(True)
+                for i, bt_id in enumerate(target_ids):
+                    row = BuildTargetRow(build_target_id=bt_id, parent=self)
+                    row.build_ready_signal.connect(self.build_ready_signal)
+                    if i > 0:
+                        separator = QFrame()
+                        separator.setFrameShape(QFrame.Shape.HLine)
+                        separator.setFrameShadow(QFrame.Shadow.Sunken)
+                        self.targets_layout.addWidget(separator)
+                    self.targets_layout.addWidget(row)
+            else:
+                self.targets_container.setVisible(False)
+
+        except Exception as e:
+            logging.info(f"Error loading build targets: {e}", exc_info=True)
+            self.targets_container.setVisible(False)
+
+    def _open_add_dialog(self):
+        dialog = BuildTargetSetupDialog(build_target_id=None)
+        dialog.build_target_created.connect(self._on_target_added)
+        dialog.exec()
+
+    def _on_target_added(self, _build_target_id: int):
+        self._refresh_targets()

--- a/build_bridge/views/widgets/publish_profile_edit_widget_itch.py
+++ b/build_bridge/views/widgets/publish_profile_edit_widget_itch.py
@@ -5,6 +5,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QFormLayout,
+    QLabel,
     QLineEdit,
     QPushButton,
     QMessageBox,
@@ -20,7 +21,7 @@ from build_bridge.core.publisher.itch.itch_publisher import (
     validate_itch_channel,
     validate_itch_target,
 )
-from build_bridge.models import BuildTarget, Project, ItchConfig, ItchPublishProfile
+from build_bridge.models import ItchConfig, ItchPublishProfile
 from build_bridge.views.dialogs import settings_dialog
 
 
@@ -29,50 +30,38 @@ class ItchPublishProfileWidget(QWidget):
 
     def __init__(self, publish_profile: ItchPublishProfile, session, parent=None):
         self.publish_profile = publish_profile
-        self.session = session  # used to commit the session and query auxiliary models
+        self.session = session
 
         super().__init__(parent=parent)
-        self.setWindowTitle(
-            f"Edit Itch.io Publish Profile ({publish_profile.build_id})"
-        )
 
         self._init_ui()
-        self._populate_fields()  # Populate UI fields after UI is built
+        self._populate_fields()
 
     def _init_ui(self):
-        """Initialize the User Interface elements."""
         main_layout = QVBoxLayout(self)
         form_layout = QFormLayout()
 
-        # --- Project Selection ---
-        self.project_combo = QComboBox()
-        self.project_combo.currentIndexChanged.connect(self._on_project_changed)
-        form_layout.addRow("Project:", self.project_combo)
-
-        # --- Read-only Build ID ---
-        self.build_id_input = QLineEdit(self.publish_profile.build_id)
-        self.build_id_input.setReadOnly(True)
-        form_layout.addRow("Build ID:", self.build_id_input)
+        # Read-only build target label
+        target_name = ""
+        if self.publish_profile.build_target:
+            target_name = self.publish_profile.build_target.name or ""
+        self.target_name_label = QLabel(target_name or "—")
+        form_layout.addRow("Build Target:", self.target_name_label)
 
         self.profile_name_input = QLineEdit()
         self.profile_name_input.setPlaceholderText("Main, Demo, QA, ...")
         form_layout.addRow("Profile Name:", self.profile_name_input)
 
-        # --- Itch.io User/Game ID ---
         self.user_game_id_input = QLineEdit()
         self.user_game_id_input.setPlaceholderText("username/game-slug")
         self.user_game_id_input.setToolTip("Format: username/game-slug")
         form_layout.addRow("User/Game ID:", self.user_game_id_input)
 
-        # --- Itch.io Channel Name ---
         self.channel_name_input = QLineEdit()
         self.channel_name_input.setPlaceholderText("default-channel")
-        self.channel_name_input.setToolTip(
-            "The channel name for publishing (e.g., windows-beta)"
-        )
+        self.channel_name_input.setToolTip("The channel name for publishing (e.g., windows-beta)")
         form_layout.addRow("Channel Name:", self.channel_name_input)
 
-        # --- Itch.io Authentication ---
         auth_layout = QHBoxLayout()
         self.auth_combo = QComboBox()
         self.auth_combo.setToolTip("Select the Itch.io account to use for publishing.")
@@ -87,40 +76,12 @@ class ItchPublishProfileWidget(QWidget):
         self.setLayout(main_layout)
 
     def _populate_fields(self):
-        """Populate UI fields with data from self.profile."""
-
-        with (
-            self.session.no_autoflush
-        ):  # no autoflush because we might be editing a profile that is not saved yet.
+        with self.session.no_autoflush:
             if not self.publish_profile:
-                # This case should ideally be handled before UI init, but as a safeguard:
                 QMessageBox.critical(self, "Error", "Profile data is not available.")
                 return
 
-            # Load Projects into ComboBox
-            self._load_projects()
-
-            # Load Auth options into ComboBox
             self._refresh_auth_options()
-
-            # --- Populate based on loaded/new profile ---
-            if (
-                self.publish_profile.id is not None
-            ):  # Check if it's an existing profile (has an ID)
-                # Select current project
-                if self.publish_profile.project:
-                    project_index = self.project_combo.findData(
-                        self.publish_profile.project.id
-                    )  # Find by ID
-                    if project_index >= 0:
-                        self.project_combo.setCurrentIndex(project_index)
-                    else:
-                        # Handle case where saved project is no longer valid
-                        QMessageBox.warning(
-                            self,
-                            "Warning",
-                            f"Saved project '{self.publish_profile.project.name}' not found. Please select a project.",
-                        )
 
             self.profile_name_input.setText(
                 (self.publish_profile.description or "").strip() or "Main"
@@ -129,90 +90,37 @@ class ItchPublishProfileWidget(QWidget):
             existing_channel = self.publish_profile.itch_channel_name
             channel_name = ""
 
-            # Check we dont have an existing channel
-            if existing_channel and not existing_channel == "":
-                logging.info(
-                    f"ItchPublishProfileWidget: Setting initial channel name to existing value: {existing_channel}"
-                )
+            if existing_channel and existing_channel != "":
                 channel_name = existing_channel
             else:
-                bt = self.session.query(
-                    BuildTarget
-                ).one_or_none()  # ASSUMED ONE FOR WHOLE APP
-
-                if bt:
-                    target_platform_lowercase = bt.target_platform.lower()
-                    logging.info(
-                        f"ItchPublishProfileWidget: Setting initial channel name to inferred" \
-                        f"from platform of build target: {target_platform_lowercase}"
-                    )
-
-                    channel_name = target_platform_lowercase
+                bt = self.publish_profile.build_target
+                if bt and bt.target_platform:
+                    try:
+                        channel_name = bt.target_platform.value.lower()
+                    except Exception:
+                        pass
 
             self.channel_name_input.setText(channel_name)
 
             existing_game_id = self.publish_profile.itch_user_game_id
             game_id = ""
 
-            if existing_game_id and not existing_game_id == "":
+            if existing_game_id and existing_game_id != "":
                 game_id = existing_game_id
             else:
-                # Do we have itch configured AND a project?
                 conf = self.session.query(ItchConfig).one_or_none()
-                proj = self.session.query(Project).one_or_none()
-
-                if conf and proj:
-                    # Then we can make a guess
-                    game_id = f"{conf.username}/{proj.name.lower().replace(' ', '-')}"
+                project = self.publish_profile.project
+                if conf and project:
+                    game_id = f"{conf.username}/{project.name.lower().replace(' ', '-')}"
 
             self.user_game_id_input.setText(game_id)
 
-        self._on_project_changed()
-
-    def _load_projects(self):
-        """Load all projects into the project dropdown."""
-        self.project_combo.clear()
-        try:
-            projects = self.session.query(Project).order_by(Project.name).all()
-            if not projects:
-                self.project_combo.addItem("No projects found", None)
-                self.project_combo.setEnabled(False)
-                QMessageBox.warning(
-                    self,
-                    "No Projects",
-                    "No projects found in the database. Please add projects first.",
-                )
-            else:
-                self.project_combo.addItem(
-                    "Select a Project...", None
-                )  # Placeholder item
-                for project in projects:
-                    # Store project ID as data for reliable retrieval
-                    self.project_combo.addItem(project.name, project.id)
-                self.project_combo.setCurrentIndex(1)
-        except Exception as e:
-            QMessageBox.critical(
-                self, "Database Error", f"Failed to load projects: {e}"
-            )
-            self.project_combo.setEnabled(False)
-
-    def _on_project_changed(self):
-        # If project changes, we update the publish profile
-        if current_proj := self.project_combo.currentData():  # data = proj_id
-            project = self.session.query(Project).get(current_proj)
-            self.publish_profile.project = project
-
     def _open_itch_settings(self):
-        settings = settings_dialog.SettingsDialog(
-            default_page=2
-        )  # Assuming Itch.io settings is page 3
+        settings = settings_dialog.SettingsDialog(default_page=2)
         settings.exec()
-
-        # Refresh settings when back
         self._refresh_auth_options()
 
     def _refresh_auth_options(self):
-        """Refresh the Itch.io Auth dropdown. This is to detect if there is a configured ItchConfig in the db."""
         self.auth_combo.clear()
         current_itch_config_id = getattr(self.publish_profile, "itch_config_id", None)
 
@@ -233,40 +141,24 @@ class ItchPublishProfileWidget(QWidget):
 
                 if current_itch_config_id is not None:
                     selected_index = self.auth_combo.findData(current_itch_config_id)
-                    self.auth_combo.setCurrentIndex(
-                        selected_index if selected_index >= 0 else 0
-                    )
+                    self.auth_combo.setCurrentIndex(selected_index if selected_index >= 0 else 0)
                 else:
                     self.auth_combo.setCurrentIndex(1 if len(itch_configs) == 1 else 0)
 
             except Exception as e:
-                QMessageBox.critical(
-                    self,
-                    "Database Error",
-                    f"Failed to load Itch.io authentications: {e}",
-                )
+                QMessageBox.critical(self, "Database Error",
+                                      f"Failed to load Itch.io authentications: {e}")
                 self.auth_combo.setEnabled(False)
 
     def save_profile(self):
-        """Validate inputs and save the current profile's details."""
         if not self.publish_profile:
             QMessageBox.critical(self, "Error", "Cannot save, profile data is missing.")
             return False
 
-        # --- Input Validation ---
-        selected_project_id = self.project_combo.currentData()
-        if selected_project_id is None:
-            QMessageBox.warning(self, "Validation Error", "Please select a Project.")
-            self.project_combo.setFocus()
-            return False
-
         selected_auth_id = self.auth_combo.currentData()
         if selected_auth_id is None:
-            QMessageBox.warning(
-                self,
-                "Validation Error",
-                "Please select an Itch.io Authentication account.",
-            )
+            QMessageBox.warning(self, "Validation Error",
+                                  "Please select an Itch.io Authentication account.")
             self.auth_combo.setFocus()
             return False
 
@@ -274,10 +166,7 @@ class ItchPublishProfileWidget(QWidget):
         user_game_id = self.user_game_id_input.text().strip()
         channel_name = self.channel_name_input.text().strip()
         try:
-            validate_itch_target(
-                user_game_id,
-                selected_auth.username if selected_auth else None,
-            )
+            validate_itch_target(user_game_id, selected_auth.username if selected_auth else None)
             validate_itch_channel(channel_name)
         except InvalidConfigurationError as e:
             QMessageBox.warning(self, "Validation Error", str(e))
@@ -286,35 +175,25 @@ class ItchPublishProfileWidget(QWidget):
 
         profile_name = self.profile_name_input.text().strip()
         if not profile_name:
-            QMessageBox.warning(
-                self, "Validation Error", "Please enter a Profile Name."
-            )
+            QMessageBox.warning(self, "Validation Error", "Please enter a Profile Name.")
             self.profile_name_input.setFocus()
             return False
 
         try:
-
-            # Add profile to session if it don't exist (it was created by the outer widget (PublishProfileEntry))
             if not object_session(self.publish_profile):
                 self.session.add(self.publish_profile)
 
-            # Assign validated values (including the required project)
-            self.publish_profile.project_id = selected_project_id
             self.publish_profile.description = profile_name
             self.publish_profile.itch_user_game_id = user_game_id
             self.publish_profile.itch_channel_name = channel_name
             self.publish_profile.itch_config_id = selected_auth_id
 
-            # --- Commit Changes ---
             self.session.commit()
             self.profile_saved_signal.emit()
-
             QMessageBox.information(self, "Success", "Profile saved successfully.")
             return True
 
         except Exception as e:
-            self.session.rollback()  # Rollback on any error during commit
-            QMessageBox.critical(
-                self, "Save Error", f"An error occurred while saving:\n{e}"
-            )
+            self.session.rollback()
+            QMessageBox.critical(self, "Save Error", f"An error occurred while saving:\n{e}")
             return False

--- a/build_bridge/views/widgets/publish_profile_edit_widget_steam.py
+++ b/build_bridge/views/widgets/publish_profile_edit_widget_steam.py
@@ -1,13 +1,14 @@
 import copy
 import logging
 import os
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QHBoxLayout,
     QFormLayout,
+    QLabel,
     QLineEdit,
     QPushButton,
     QMessageBox,
@@ -23,7 +24,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import pyqtSignal
 from sqlalchemy.orm import object_session
 
-from build_bridge.models import Project, SteamConfig, SteamPublishProfile
+from build_bridge.models import SteamConfig, SteamPublishProfile
 from build_bridge.views.dialogs import settings_dialog
 
 
@@ -39,18 +40,15 @@ class SteamPublishProfileWidget(QWidget):
         self._populate_fields()
 
     def _init_ui(self):
-        """Initialize the User Interface elements with Tabs."""
         main_layout = QVBoxLayout(self)
-        common_form_layout = QFormLayout()  # Layout for fields outside tabs
+        common_form_layout = QFormLayout()
 
-        # --- Common Fields (Outside Tabs) ---
-        self.project_combo = QComboBox()
-        self.project_combo.currentIndexChanged.connect(self._on_project_changed)
-        common_form_layout.addRow("Project:", self.project_combo)
-
-        self.build_id_input = QLineEdit(self.publish_profile.build_id)
-        self.build_id_input.setReadOnly(True)
-        common_form_layout.addRow("Build ID:", self.build_id_input)
+        # Read-only build target label
+        target_name = ""
+        if self.publish_profile.build_target:
+            target_name = self.publish_profile.build_target.name or ""
+        self.target_name_label = QLabel(target_name or "—")
+        common_form_layout.addRow("Build Target:", self.target_name_label)
 
         self.builder_path_display = QLineEdit()
         self.builder_path_display.setReadOnly(True)
@@ -59,7 +57,7 @@ class SteamPublishProfileWidget(QWidget):
         )
         common_form_layout.addRow("Builder Path:", self.builder_path_display)
 
-        main_layout.addLayout(common_form_layout)  # Add common fields first
+        main_layout.addLayout(common_form_layout)
 
         self.app_id_input = QSpinBox()
         self.app_id_input.setRange(0, 9999999)
@@ -67,21 +65,17 @@ class SteamPublishProfileWidget(QWidget):
         common_form_layout.addRow("App ID:", self.app_id_input)
 
         self.description_input = QLineEdit()
-        self.description_input.setPlaceholderText(
-            "Main, Demo, QA, ..."
-        )
+        self.description_input.setPlaceholderText("Main, Demo, QA, ...")
         common_form_layout.addRow("Profile Name:", self.description_input)
 
         self.depots_table = self._create_depots_table()
         main_layout.addWidget(self.depots_table)
         main_layout.addLayout(self._create_depot_buttons(self.depots_table))
 
-        # Common Fields (Bottom)
         auth_layout = QHBoxLayout()
         self.auth_combo = QComboBox()
         self.auth_combo.setToolTip("Select the Steam account to use for publishing.")
         auth_layout.addWidget(self.auth_combo)
-        # Add steam config button next to combo, or below separately
         common_form_layout.addRow("Steam Auth:", auth_layout)
 
         self.steam_config_button = QPushButton("Manage Steam Configuration")
@@ -91,90 +85,29 @@ class SteamPublishProfileWidget(QWidget):
         self.setLayout(main_layout)
 
     def _populate_fields(self):
-        """Populate UI fields with data from self.publish_profile."""
         with self.session.no_autoflush:
-            self._load_projects()
             self._refresh_auth_options()
+            self._update_builder_path()
 
-            # Populate common fields
-            if self.publish_profile.project:
-                project_index = self.project_combo.findData(
-                    self.publish_profile.project.id
-                )
-                if project_index >= 0:
-                    self.project_combo.setCurrentIndex(project_index)
-                else:
-                    QMessageBox.warning(
-                        self,
-                        "Warning",
-                        f"Saved project '{self.publish_profile.project.name}' not found.",
-                    )
-                # Trigger builder path update
-                self._on_project_changed()  # Ensure builder path is updated early
-            else:
-                if (
-                    self.project_combo.count() > 1
-                ):  # Check if there are projects loaded besides placeholder
-                    self.project_combo.setCurrentIndex(
-                        1
-                    )  # Select first actual project if profile has none
-                else:
-                    self.project_combo.setCurrentIndex(
-                        0
-                    )  # Select placeholder if no projects
-                self._on_project_changed()  # Update builder path even if no project is selected initially
-
-            # REGULAR TAB
-            # Only use current profile values to avoid cross-profile data bleed.
             app_id = self.publish_profile.app_id or 0
             self.app_id_input.setValue(app_id)
 
-            profile_name = (
-                self.publish_profile.description
-                or "Main"
-            )
+            profile_name = self.publish_profile.description or "Main"
             self.description_input.setText(profile_name)
 
-            # Regular Depots
             depots = copy.deepcopy(self.publish_profile.depots or {})
-            if depots and self.publish_profile.project:
-                depot_id = next(iter(depots))
-                depots[depot_id] = (
-                    f"{self.publish_profile.project.builds_path}/"
-                    f"{self.build_id_input.text()}"
-                ).replace(os.sep, "/")
-
             self._load_depots_table(self.depots_table, depots)
 
-    def _load_projects(self):
-        """Load all projects into the project dropdown."""
-        self.project_combo.clear()
+    def _update_builder_path(self):
+        path = "N/A"
         try:
-            projects = self.session.query(Project).order_by(Project.name).all()
-            if not projects:
-                self.project_combo.addItem("No projects found", None)
-                self.project_combo.setEnabled(False)
-                QMessageBox.warning(
-                    self,
-                    "No Projects",
-                    "No projects found in the database. Please add projects first.",
-                )
-            else:
-                self.project_combo.addItem(
-                    "Select a Project...", None
-                )  # Placeholder item
-                for project in projects:
-                    # Store project ID as data for reliable retrieval
-                    self.project_combo.addItem(project.name, project.id)
-                self.project_combo.setCurrentIndex(1)
+            if self.publish_profile.build_target:
+                path = self.publish_profile.builder_path or "N/A"
         except Exception as e:
-            QMessageBox.critical(
-                self, "Database Error", f"Failed to load projects: {e}"
-            )
-            self.project_combo.setEnabled(False)
+            path = f"Error: {e}"
+        self.builder_path_display.setText(str(path))
 
     def _refresh_auth_options(self):
-        """Refresh the Steam Auth dropdown and re-select current SteamConfig when possible."""
         self.auth_combo.clear()
         current_steam_config_id = getattr(self.publish_profile, "steam_config_id", None)
         steam_configs = (
@@ -197,54 +130,25 @@ class SteamPublishProfileWidget(QWidget):
                 self.auth_combo.setCurrentIndex(0)
 
         except Exception as e:
-            QMessageBox.critical(
-                self, "Database Error", f"Failed to load Steam Config: {e}"
-            )
+            QMessageBox.critical(self, "Database Error", f"Failed to load Steam Config: {e}")
             self.auth_combo.setEnabled(False)
 
-    def _on_project_changed(self):
-        """Update the read-only builder path based on selected project and update profile project."""
-        path = "N/A - Select a project"
-        if self.publish_profile.project is None and self.project_combo.currentData():
-            # If selected project is valid and exists, then assign it to the profile
-            project = self.session.query(Project).get(self.project_combo.currentData())
-            if project:
-                self.publish_profile.project = project
-
-        if self.publish_profile.project is not None:
-            try:
-                path = self.publish_profile.builder_path
-            except NoResultFound:
-                path = "N/A - Project not found"
-            except Exception as e:
-                path = f"Error loading path: {e}"
-
-        self.builder_path_display.setText(path)
-
     def _create_depots_table(self):
-        """Helper function to create a depots table widget."""
         table = QTableWidget(0, 3)
         table.setHorizontalHeaderLabels(["Depot ID", "Path (Directory)", "Browse"])
         table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
         table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         table.horizontalHeader().setStretchLastSection(False)
-        table.horizontalHeader().setSectionResizeMode(
-            0, QHeaderView.ResizeMode.ResizeToContents
-        )
+        table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
         table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
-        table.horizontalHeader().setSectionResizeMode(
-            2, QHeaderView.ResizeMode.ResizeToContents
-        )
+        table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
         return table
 
     def _create_depot_buttons(self, target_table):
-        """Helper function to create Add/Remove buttons for a specific depot table."""
         layout = QHBoxLayout()
         add_button = QPushButton("Add Depot")
-        # Pass the target table to the slot
         add_button.clicked.connect(lambda: self._add_depot_row(target_table))
         remove_button = QPushButton("Remove Selected Depot")
-        # Pass the target table to the slot
         remove_button.clicked.connect(lambda: self._remove_depot_row())
         layout.addWidget(add_button)
         layout.addWidget(remove_button)
@@ -252,19 +156,14 @@ class SteamPublishProfileWidget(QWidget):
         return layout
 
     def _load_depots_table(self, table_widget: QTableWidget, depots_dict: dict):
-        """Load depots into the specified table."""
-        table_widget.setRowCount(0)  # Clear existing rows
+        table_widget.setRowCount(0)
         if not isinstance(depots_dict, dict):
             logging.info(f"Warning: Depots data is not a dictionary: {depots_dict}")
             return
         for depot_id, depot_path in depots_dict.items():
-            # Pass the target table to _insert_depot_row
             self._insert_depot_row(table_widget, depot_id, depot_path)
 
-    def _insert_depot_row(
-        self, table_widget: QTableWidget, depot_id=None, depot_path=None
-    ):
-        """Inserts a row into the specified depot table and sets up widgets."""
+    def _insert_depot_row(self, table_widget: QTableWidget, depot_id=None, depot_path=None):
         row = table_widget.rowCount()
         table_widget.insertRow(row)
 
@@ -275,42 +174,31 @@ class SteamPublishProfileWidget(QWidget):
         table_widget.setItem(row, 1, path_item)
 
         browse_button = QPushButton("Browse...")
-
         browse_button.clicked.connect(
-            lambda checked=False, tbl=table_widget, r=row: self._browse_depot_path(
-                tbl, r
-            )
+            lambda checked=False, tbl=table_widget, r=row: self._browse_depot_path(tbl, r)
         )
         table_widget.setCellWidget(row, 2, browse_button)
 
     def _add_depot_row(self, table_widget: QTableWidget):
-        """Adds a new, empty row to the specified depots table."""
         self._insert_depot_row(table_widget)
         table_widget.scrollToBottom()
 
     def _remove_depot_row(self):
-        """Removes the currently selected row from the depots table."""
         current_row = self.depots_table.currentRow()
         if current_row >= 0:
             self.depots_table.removeRow(current_row)
         else:
-            QMessageBox.warning(
-                self, "No Selection", "Please select a depot row to remove."
-            )
+            QMessageBox.warning(self, "No Selection", "Please select a depot row to remove.")
 
     def _browse_depot_path(self, table_widget: QTableWidget, row):
-        """Open a directory dialog to select a depot path for the specified table."""
         current_path_item = table_widget.item(row, 1)
         start_dir = ""
         if current_path_item and current_path_item.text():
             start_dir = current_path_item.text()
-        elif self.publish_profile.project and self.publish_profile.project.builds_path:
-            # Default to project's build path if available
-            start_dir = str(self.publish_profile.project.builds_path)
+        elif self.publish_profile.build_target and self.publish_profile.build_target.builds_path:
+            start_dir = str(self.publish_profile.build_target.builds_path)
 
-        path = QFileDialog.getExistingDirectory(
-            self, "Select Depot Directory", start_dir
-        )
+        path = QFileDialog.getExistingDirectory(self, "Select Depot Directory", start_dir)
         if path:
             table_widget.setItem(row, 1, QTableWidgetItem(path))
 
@@ -320,25 +208,18 @@ class SteamPublishProfileWidget(QWidget):
         self._refresh_auth_options()
 
     def _collect_and_validate_depots(self, table_widget: QTableWidget):
-        """Helper to collect and validate depots from a specific table.
-        Returns a dictionary of depots or None if validation fails.
-        """
         depots_to_save = {}
         for row in range(table_widget.rowCount()):
             id_item = table_widget.item(row, 0)
             path_item = table_widget.item(row, 1)
 
             if not id_item or not id_item.text().strip():
-                QMessageBox.warning(
-                    self, "Validation Error", f"Depot ID is missing in row {row+1}."
-                )
+                QMessageBox.warning(self, "Validation Error", f"Depot ID is missing in row {row+1}.")
                 table_widget.selectRow(row)
                 table_widget.setFocus()
                 return None
             if not path_item or not path_item.text().strip():
-                QMessageBox.warning(
-                    self, "Validation Error", f"Depot Path is missing in row {row+1}."
-                )
+                QMessageBox.warning(self, "Validation Error", f"Depot Path is missing in row {row+1}.")
                 table_widget.selectRow(row)
                 table_widget.setFocus()
                 return None
@@ -348,33 +229,23 @@ class SteamPublishProfileWidget(QWidget):
                 if depot_id <= 0:
                     raise ValueError("Depot ID must be positive")
             except ValueError:
-                QMessageBox.warning(
-                    self,
-                    "Validation Error",
-                    f"Invalid Depot ID '{id_item.text()}' in row {row+1}. Must be a positive integer.",
-                )
+                QMessageBox.warning(self, "Validation Error",
+                                     f"Invalid Depot ID '{id_item.text()}' in row {row+1}. Must be a positive integer.")
                 table_widget.selectRow(row)
                 table_widget.editItem(id_item)
                 return None
 
             depot_path = path_item.text().strip()
-
             if not os.path.exists(depot_path):
-                QMessageBox.warning(
-                    self,
-                    "Validation Error",
-                    f"Depot path in row {row+1} does not exist:\n{depot_path}",
-                )
+                QMessageBox.warning(self, "Validation Error",
+                                     f"Depot path in row {row+1} does not exist:\n{depot_path}")
                 table_widget.selectRow(row)
                 table_widget.setFocus()
                 return None
 
             if depot_id in depots_to_save:
-                QMessageBox.warning(
-                    self,
-                    "Validation Error",
-                    f"Duplicate Depot ID '{depot_id}' found in row {row+1}.",
-                )
+                QMessageBox.warning(self, "Validation Error",
+                                     f"Duplicate Depot ID '{depot_id}' found in row {row+1}.")
                 table_widget.selectRow(row)
                 table_widget.editItem(id_item)
                 return None
@@ -383,46 +254,25 @@ class SteamPublishProfileWidget(QWidget):
         return depots_to_save
 
     def save_profile(self):
-        """Validate inputs and save the current profile's details for both tabs."""
         if not self.publish_profile:
             QMessageBox.critical(self, "Error", "Cannot save, profile data is missing.")
             return False
 
-        # Common Input Validation
-        selected_project_id = self.project_combo.currentData()
-        if selected_project_id is None:
-            QMessageBox.warning(self, "Validation Error", "Please select a Project.")
-            self.project_combo.setFocus()
-            return False
-
         selected_auth_id = self.auth_combo.currentData()
         if selected_auth_id is None:
-            QMessageBox.warning(
-                self,
-                "Validation Error",
-                "Please select a Steam Authentication account.",
-            )
+            QMessageBox.warning(self, "Validation Error", "Please select a Steam Authentication account.")
             self.auth_combo.setFocus()
             return False
 
         profile_name = self.description_input.text().strip()
         if not profile_name:
-            QMessageBox.warning(
-                self,
-                "Validation Error",
-                "Please enter a Profile Name.",
-            )
+            QMessageBox.warning(self, "Validation Error", "Please enter a Profile Name.")
             self.description_input.setFocus()
             return False
 
-        # Regular Tab Validation
         app_id = self.app_id_input.value()
         if app_id <= 0:
-            QMessageBox.warning(
-                self,
-                "Validation Error",
-                "Please enter a valid App ID (must be > 0).",
-            )
+            QMessageBox.warning(self, "Validation Error", "Please enter a valid App ID (must be > 0).")
             self.app_id_input.setFocus()
             return False
 
@@ -430,41 +280,25 @@ class SteamPublishProfileWidget(QWidget):
         if regular_depots is None:
             return False
 
-        # Update Profile Object
         try:
             if not object_session(self.publish_profile):
                 self.session.add(self.publish_profile)
 
-            # Assign common validated values
-            self.publish_profile.project_id = selected_project_id
             self.publish_profile.steam_config_id = selected_auth_id
-
-            # Assign Regular Tab values
             self.publish_profile.app_id = app_id
             self.publish_profile.description = profile_name
             self.publish_profile.depots = regular_depots
 
-            # Commit Changes
             self.session.commit()
             self.profile_saved_signal.emit()
-            QMessageBox.information(
-                self,
-                "Success",
-                f"Steam Profile for build {self.publish_profile.build_id} saved successfully.",
-            )
+            QMessageBox.information(self, "Success", "Steam profile saved successfully.")
             return True
 
         except AttributeError as e:
             self.session.rollback()
-            QMessageBox.critical(
-                self,
-                "Save Error",
-                f"An error occurred while saving the Steam publish profile:\n\nDetails: {e}",
-            )
+            QMessageBox.critical(self, "Save Error", f"Error saving Steam publish profile:\n{e}")
             return False
         except Exception as e:
             self.session.rollback()
-            QMessageBox.critical(
-                self, "Save Error", f"An error occurred while saving:\n{e}"
-            )
+            QMessageBox.critical(self, "Save Error", f"An error occurred while saving:\n{e}")
             return False

--- a/build_bridge/views/widgets/publish_profile_read_widgets.py
+++ b/build_bridge/views/widgets/publish_profile_read_widgets.py
@@ -1,4 +1,6 @@
 import os, logging
+from datetime import datetime
+from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QWidget,
@@ -18,6 +20,7 @@ from PyQt6.QtGui import QFont
 
 from build_bridge.models import (
     Build,
+    BuildStatusEnum,
     BuildTarget,
     Project,
     PublishProfile,
@@ -50,6 +53,16 @@ class PublishProfileListWidget(QWidget):
         toolbar_layout = QHBoxLayout()
         toolbar_layout.setContentsMargins(0, 0, 0, 0)
         toolbar_layout.addStretch(1)
+
+        self.import_button = QPushButton("Import from disk")
+        self.import_button.setObjectName("ghostButton")
+        self.import_button.setIcon(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon)
+        )
+        self.import_button.setToolTip("Scan archive directory for existing build folders and import them")
+        self.import_button.clicked.connect(self._import_from_disk)
+        self.import_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        toolbar_layout.addWidget(self.import_button)
 
         self.refresh_button = QPushButton("Refresh")
         self.refresh_button.setObjectName("ghostButton")
@@ -133,6 +146,63 @@ class PublishProfileListWidget(QWidget):
             self.vbox.addWidget(widget)
 
         self.vbox.addStretch(1)
+
+    def _import_from_disk(self):
+        """Scan archive_dir/project_name/ for version folders not yet in the DB."""
+        self.session.expire_all()
+        project = self.session.query(Project).first()
+        if not project or not project.archive_directory:
+            QMessageBox.warning(self, "Import", "No project configured.")
+            return
+
+        targets = (
+            self.session.query(BuildTarget)
+            .filter_by(project_id=project.id)
+            .order_by(BuildTarget.id)
+            .all()
+        )
+        if not targets:
+            QMessageBox.warning(self, "Import", "No build targets found. Add a build target first.")
+            return
+
+        # Scan archive_dir/project_name/ — subdirs that are NOT target names are
+        # old-style version folders (pre-refactor builds).
+        scan_root = Path(project.archive_directory) / project.name
+        if not scan_root.exists():
+            QMessageBox.information(self, "Import", f"Directory not found:\n{scan_root}")
+            return
+
+        target_names = {t.name for t in targets if t.name}
+        existing_paths = {b.output_path for b in self.session.query(Build.output_path).all()}
+
+        imported = 0
+        for entry in sorted(scan_root.iterdir()):
+            if not entry.is_dir() or entry.name in target_names:
+                continue
+            version = entry.name
+            output_path = str(entry)
+            if output_path in existing_paths:
+                continue
+
+            # Assign to the first (or only) build target; ambiguity is rare in
+            # the single-project model this app uses.
+            build = Build(
+                build_target_id=targets[0].id,
+                version=version,
+                output_path=output_path,
+                status=BuildStatusEnum.success,
+                created_at=datetime.fromtimestamp(entry.stat().st_mtime),
+            )
+            self.session.add(build)
+            imported += 1
+
+        self.session.commit()
+
+        if imported:
+            QMessageBox.information(self, "Import", f"Imported {imported} build(s).")
+            self.refresh_builds()
+        else:
+            QMessageBox.information(self, "Import", "No new builds found to import.")
 
     def closeEvent(self, a0):
         self.session.close()

--- a/build_bridge/views/widgets/publish_profile_read_widgets.py
+++ b/build_bridge/views/widgets/publish_profile_read_widgets.py
@@ -17,6 +17,8 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont
 
 from build_bridge.models import (
+    Build,
+    BuildTarget,
     Project,
     PublishProfile,
     StoreEnum,
@@ -31,20 +33,13 @@ from build_bridge.views.dialogs.publish_profile_manager_dialog import (
     PublishProfileManagerDialog,
 )
 
+
 class PublishProfileListWidget(QWidget):
-    def __init__(self, builds_dir: str = None):
+    def __init__(self):
         super().__init__()
-        # OWNS SESSION FOR ALL OPERATIONS ON PUBLISH PROFILES.
-        # It starts here and gets passed to each Entry widget.
-        # Then each entry widget passes this down further to its related dialogs.
         self.session = SessionFactory()
 
         self.setWindowTitle("Available Builds")
-
-        # Store the directory path internally - set the initial value
-        self.monitored_directory = builds_dir
-
-        # Set a more compact initial size and minimum size
         self.setGeometry(100, 100, 600, 400)
         self.setMinimumSize(500, 300)
 
@@ -52,7 +47,6 @@ class PublishProfileListWidget(QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(10)
 
-        # --- Refresh Button ---
         toolbar_layout = QHBoxLayout()
         toolbar_layout.setContentsMargins(0, 0, 0, 0)
         toolbar_layout.addStretch(1)
@@ -62,30 +56,19 @@ class PublishProfileListWidget(QWidget):
         self.refresh_button.setIcon(
             self.style().standardIcon(QStyle.StandardPixmap.SP_BrowserReload)
         )
-        self.refresh_button.setToolTip(
-            "Rescan the currently monitored build directory for changes"
-        )
+        self.refresh_button.setToolTip("Refresh the builds list from the database")
         self.refresh_button.clicked.connect(self.refresh_builds)
-        self.refresh_button.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        )
+        self.refresh_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         toolbar_layout.addWidget(self.refresh_button)
         main_layout.addLayout(toolbar_layout)
-        # --- End Refresh Button ---
 
         self.scroll_area = QScrollArea()
         self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setVisible(True)  # Always visible
-        self.scroll_area.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
-        )
-        self.scroll_area.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        self.scroll_area.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
-        self.scroll_area.setMinimumHeight(100)  # Ensure scroll area doesn't disappear
+        self.scroll_area.setVisible(True)
+        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.scroll_area.setMinimumHeight(100)
 
         self.scroll_content = QWidget()
         self.vbox = QVBoxLayout(self.scroll_content)
@@ -98,158 +81,109 @@ class PublishProfileListWidget(QWidget):
         self.empty_message_label.setObjectName("emptyState")
         self.empty_message_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.empty_message_label.setVisible(True)
-        self.empty_message_label.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
-        )
+        self.empty_message_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         main_layout.addWidget(self.scroll_area)
         main_layout.addWidget(self.empty_message_label)
-        # --- End Scroll Area Setup ---
 
         self.refresh_builds()
 
-    def refresh_builds(self, new_dir: str = None):
-        """
-        Refreshes the list of builds displayed by scanning the monitored directory.
-        Clears previous entries and shows/hides the 'No builds' message.
-        """
-        logging.info(f"=====NEW DIR: {new_dir}=====")
-        if not new_dir:
-            project = self.session.query(Project).first()
-            if project:
-                self.monitored_directory = project.builds_path
-
-        # Update monitored_directory only if a new valid directory is provided
-        if new_dir is not None and os.path.isdir(new_dir):
-            logging.info(f"  - Updating monitored directory to: {new_dir}")
-            self.monitored_directory = new_dir
-        else:
-            logging.info(f"  - Keeping existing monitored directory: {self.monitored_directory}")
-
-        # Use the current monitored_directory for scanning
-        dir_to_scan = self.monitored_directory
-        logging.info(f"  - Refreshing based on directory: {dir_to_scan}")
-
-        # --- 1. Clear existing widgets ---
+    def refresh_builds(self):
+        """Re-queries the DB and rebuilds the builds list."""
         while self.vbox.count():
             child = self.vbox.takeAt(0)
             if child.widget():
-                logging.info(f"  - Clearing widget: {child.widget()}")
                 child.widget().deleteLater()
 
-        # --- 2. Check if the directory is valid ---
-        is_valid_dir = False
-        if dir_to_scan and os.path.isdir(dir_to_scan):
-            is_valid_dir = True
-            logging.info(f"  - Directory '{dir_to_scan}' is valid.")
-        else:
-            logging.info(f"  - Directory '{dir_to_scan}' is invalid or None.")
-            self.empty_message_label.setText(
-                "Builds directory not set." if not dir_to_scan else f"Directory not found:\n{dir_to_scan}"
+        try:
+            self.session.expire_all()
+            project = self.session.query(Project).first()
+            if not project:
+                self.empty_message_label.setText("No project configured.")
+                self.empty_message_label.setVisible(True)
+                self.scroll_area.setVisible(False)
+                return
+
+            builds = (
+                self.session.query(Build)
+                .join(BuildTarget)
+                .filter(BuildTarget.project_id == project.id)
+                .order_by(Build.created_at.desc())
+                .all()
             )
 
-        # If directory is invalid, show empty state and return
-        if not is_valid_dir:
+        except Exception as e:
+            logging.info(f"Error querying builds: {e}", exc_info=True)
+            self.empty_message_label.setText("Error loading builds.")
             self.empty_message_label.setVisible(True)
-            logging.info("  - Showing empty message (invalid dir), returning.")
+            self.scroll_area.setVisible(False)
             return
 
-        # --- 3. Populate builds if directory is valid ---
-        builds_found = False
-        try:
-            entries = sorted(os.listdir(dir_to_scan))
-            logging.info(f"  - Scanning entries: {entries}")
+        if not builds:
+            self.empty_message_label.setText("No builds available.")
+            self.empty_message_label.setVisible(True)
+            self.scroll_area.setVisible(False)
+            return
 
-            for entry in entries:
-                full_path = os.path.join(dir_to_scan, entry)
-                is_config_dir = any(entry == store.value for store in StoreEnum)
+        self.scroll_area.setVisible(True)
+        self.empty_message_label.setVisible(False)
 
-                if os.path.isdir(full_path) and not is_config_dir:
-                    logging.info(f"    - Found potential build directory: {entry}")
-                    widget = PublishProfileEntry(full_path, session=self.session)
-                    self.vbox.addWidget(widget)
-                    builds_found = True
-                elif is_config_dir:
-                    logging.info(f"    - Skipping config directory: {entry}")
-                else:
-                    logging.info(f"    - Skipping non-directory entry: {entry}")
-
-        except OSError as e:
-            logging.info(f"  - Error listing directory '{dir_to_scan}': {e}")
-            self.empty_message_label.setText(f"Error reading directory:\n{e}")
-            builds_found = False
-        except Exception as e:
-            logging.info(f"  - Unexpected error processing directory '{dir_to_scan}': {e}")
-            self.empty_message_label.setText("An unexpected error occurred.")
-            builds_found = False
+        for build in builds:
+            widget = PublishProfileEntry(build=build, session=self.session)
+            self.vbox.addWidget(widget)
 
         self.vbox.addStretch(1)
 
-        # --- 4. Set final visibility ---
-        if builds_found:
-            self.empty_message_label.setVisible(False)
-        else:
-            if is_valid_dir:
-                self.empty_message_label.setText("No builds available in the monitored directory.")
-            self.empty_message_label.setVisible(True)
+    def closeEvent(self, a0):
+        self.session.close()
+        return super().closeEvent(a0)
 
 
 class PublishProfileEntry(QWidget):
     store_publishers = {StoreEnum.itch: ItchPublisher, StoreEnum.steam: SteamPublisher}
 
-    def __init__(self, build_root, session):
+    def __init__(self, build: Build, session):
         super().__init__()
-        self.build_root = build_root
+        self.build = build
+        self.build_root = build.output_path
+        self.build_id = build.version  # kept for compatibility with existing label references
         self.publish_profile: PublishProfile | None = None
         self.session = session
 
-        if build_root and os.path.exists(build_root):
-            self.build_id = os.path.basename(build_root)
-        else:
-            self.build_id = "Invalid Path"
-            logging.info(
-                f"Warning: Invalid build_root passed to PublishTargetEntry: {build_root}"
-            )
-
-
-        # Use a responsive layout with QVBoxLayout and QHBoxLayout
         self.setObjectName("buildCard")
         self.main_layout = QVBoxLayout(self)
         self.main_layout.setContentsMargins(14, 12, 14, 12)
         self.main_layout.setSpacing(9)
 
-        # First row: Label and Platform Selector with Checkbox
+        # First row: build name + store selector
         self.top_row = QHBoxLayout()
         self.top_row.setSpacing(14)
 
-        # Build Label
-        project_name_str = "Unknown Project"
-        try:
-            project = session.query(Project).one_or_none()
-            if project:
-                project_name_str = project.name
-        except Exception as e:
-            logging.info(f"Error fetching project name: {e}")
-
         display_name_font = QFont()
         display_name_font.setBold(True)
-        self.display_name_label = QLabel(f"{project_name_str} - {self.build_id}")
+
+        target_name = ""
+        try:
+            target_name = build.build_target.name if build.build_target else ""
+        except Exception:
+            pass
+
+        self.display_name_label = QLabel(f"{target_name} — {build.version}")
         self.display_name_label.setObjectName("primaryText")
         self.display_name_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
         self.display_name_label.setWordWrap(True)
         self.display_name_label.setFont(display_name_font)
         self.top_row.addWidget(self.display_name_label)
 
-        # Platform Selector
-        self.platform_widget = QWidget()
-        self.platform_layout = QHBoxLayout(self.platform_widget)
-        self.platform_layout.setContentsMargins(0, 0, 0, 0)
-        self.platform_layout.setSpacing(5)
+        platform_widget = QWidget()
+        platform_layout = QHBoxLayout(platform_widget)
+        platform_layout.setContentsMargins(0, 0, 0, 0)
+        platform_layout.setSpacing(5)
 
-        self.store_type_label = QLabel("Store")
-        self.store_type_label.setObjectName("fieldLabel")
-        self.store_type_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        self.platform_layout.addWidget(self.store_type_label)
+        store_label = QLabel("Store")
+        store_label.setObjectName("fieldLabel")
+        store_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        platform_layout.addWidget(store_label)
 
         self.store_type_combo = QComboBox()
         self.store_type_combo.setMinimumWidth(100)
@@ -257,18 +191,14 @@ class PublishProfileEntry(QWidget):
         for store_enum in self.store_publishers.keys():
             self.store_type_combo.addItem(str(store_enum.value), store_enum)
         self.store_type_combo.setToolTip("Select the target platform for publishing this build")
-        self.platform_layout.addWidget(self.store_type_combo)
+        platform_layout.addWidget(self.store_type_combo)
 
-        # Prevent the platform layout from stretching unnecessarily
-        self.platform_widget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        self.top_row.addWidget(self.platform_widget)
-
-        # Add stretch to the end of the row to push everything to the left
+        platform_widget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.top_row.addWidget(platform_widget)
         self.top_row.addStretch(1)
-
         self.main_layout.addLayout(self.top_row)
 
-        # Second row: Selected publish profile
+        # Second row: selected publish profile
         self.profile_row = QHBoxLayout()
         self.profile_row.setSpacing(8)
         profile_label = QLabel("Publish profile")
@@ -282,24 +212,18 @@ class PublishProfileEntry(QWidget):
 
         self.manage_profiles_button = QPushButton("Change...")
         self.manage_profiles_button.setObjectName("ghostButton")
-        self.manage_profiles_button.setToolTip(
-            "Create, select, rename, edit, or delete publish profiles"
-        )
+        self.manage_profiles_button.setToolTip("Create, select, rename, edit, or delete publish profiles")
         self.manage_profiles_button.clicked.connect(self.manage_publish_profiles)
         self.profile_row.addWidget(self.manage_profiles_button)
         self.main_layout.addLayout(self.profile_row)
 
-        # Third row: Buttons
+        # Third row: action buttons
         self.bottom_row = QHBoxLayout()
         self.bottom_row.setSpacing(10)
-
         self.bottom_row.addStretch(1)
 
-        # Buttons
         browse_archive_button = QPushButton("Browse")
-        browse_archive_button.setIcon(
-            self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon)
-        )
+        browse_archive_button.setIcon(self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon))
         browse_archive_button.setToolTip(f"Open build folder:\n{self.build_root}")
         browse_archive_button.clicked.connect(self.browse_archive_directory)
         self.bottom_row.addWidget(browse_archive_button)
@@ -307,16 +231,10 @@ class PublishProfileEntry(QWidget):
         self.publish_button = QPushButton("Publish")
         self.publish_button.setObjectName("primaryButton")
         self.publish_button.clicked.connect(self.handle_publish)
-        self.publish_button.setToolTip("")
         self.bottom_row.addWidget(self.publish_button)
-
         self.main_layout.addLayout(self.bottom_row)
-        self.setLayout(self.main_layout)
 
-        # Connect signals after widgets are created
         self.store_type_combo.currentIndexChanged.connect(self.on_store_changed)
-
-        # Initial state check for publish button
         self.on_store_changed()
 
     def update_publish_button_enabled(self):
@@ -346,19 +264,22 @@ class PublishProfileEntry(QWidget):
             self._refresh_profile_summary()
             return
 
-        profiles = (
-            self.session.query(PublishProfile)
-            .filter_by(store_type=selected_store_enum, build_id=self.build_id)
-            .order_by(PublishProfile.id.asc())
-            .all()
-        )
+        try:
+            self.session.refresh(self.build)
+            profiles = [
+                p for p in self.build.build_target.publish_profiles
+                if p.store_type == selected_store_enum
+            ]
+            profiles.sort(key=lambda p: p.id)
+        except Exception as e:
+            logging.info(f"Error loading publish profiles: {e}")
+            profiles = []
 
         self.publish_profile = None
         if profiles:
             if selected_profile_id is not None:
                 self.publish_profile = next(
-                    (profile for profile in profiles if profile.id == selected_profile_id),
-                    None,
+                    (p for p in profiles if p.id == selected_profile_id), None
                 )
             if self.publish_profile is None:
                 self.publish_profile = profiles[0]
@@ -370,13 +291,11 @@ class PublishProfileEntry(QWidget):
             selected_store_enum = self.store_type_combo.currentData()
             store_label = selected_store_enum.value if selected_store_enum else "store"
             self.profile_value_label.setText(f"No {store_label} profile selected")
-            self.profile_value_label.setToolTip("Use Manage Profiles to create or select one.")
+            self.profile_value_label.setToolTip("Use Change... to create or select one.")
         else:
             profile_label = self._get_profile_label(self.publish_profile)
             self.profile_value_label.setText(profile_label)
-            self.profile_value_label.setToolTip(
-                f"Selected publish profile: {profile_label}"
-            )
+            self.profile_value_label.setToolTip(f"Selected publish profile: {profile_label}")
 
     def _on_profile_selected_from_manager(self, profile):
         if profile is None:
@@ -389,16 +308,12 @@ class PublishProfileEntry(QWidget):
     def manage_publish_profiles(self):
         selected_platform_enum = self.store_type_combo.currentData()
         if selected_platform_enum is None:
-            QMessageBox.information(
-                self,
-                "Select Store",
-                "Please select a store before managing publish profiles.",
-            )
+            QMessageBox.information(self, "Select Store", "Please select a store before managing publish profiles.")
             return
 
         manager = PublishProfileManagerDialog(
             session=self.session,
-            build_id=self.build_id,
+            build_target_id=self.build.build_target_id,
             store_type=selected_platform_enum,
             selected_profile_id=getattr(self.publish_profile, "id", None),
             parent=self,
@@ -418,9 +333,7 @@ class PublishProfileEntry(QWidget):
         selected_platform_enum = self.store_type_combo.currentData()
         if self.publish_profile is None:
             store_label = selected_platform_enum.value if selected_platform_enum else "store"
-            self.publish_button.setToolTip(
-                f"Create or select a {store_label} publish profile first."
-            )
+            self.publish_button.setToolTip(f"Create or select a {store_label} publish profile first.")
             return
 
         try:
@@ -429,19 +342,13 @@ class PublishProfileEntry(QWidget):
                 raise InvalidConfigurationError(
                     f"No publisher implementation found for {selected_platform_enum.value}"
                 )
-            
-            publisher_instance = None
+
             if selected_platform_enum == StoreEnum.steam:
-                publisher_instance = publisher_class(
-                    publish_profile=self.publish_profile
-                )
+                publisher_instance = publisher_class(publish_profile=self.publish_profile)
             else:
-                publisher_instance = publisher_class(
-                    publish_profile=self.publish_profile
-                )
+                publisher_instance = publisher_class(publish_profile=self.publish_profile)
 
             publisher_instance.validate_publish_profile()
-
             self.publish_button.setToolTip(
                 f"Publish build '{self.build_id}' to {selected_platform_enum.value}"
             )
@@ -484,9 +391,7 @@ class PublishProfileEntry(QWidget):
                 )
 
         except OSError as e:
-            raise InvalidConfigurationError(
-                f"Error accessing build directory content: {e}"
-            )
+            raise InvalidConfigurationError(f"Error accessing build directory content: {e}")
 
     def browse_archive_directory(self):
         if self.build_root and os.path.isdir(self.build_root):
@@ -497,18 +402,9 @@ class PublishProfileEntry(QWidget):
                     import subprocess
                     subprocess.Popen(["open", self.build_root])
             except Exception as e:
-                logging.info(f"Error opening directory {self.build_root}: {e}")
-                QMessageBox.warning(
-                    self,
-                    "Error",
-                    f"Could not open directory:\n{self.build_root}\n\nError: {e}",
-                )
+                QMessageBox.warning(self, "Error", f"Could not open directory:\n{self.build_root}\n\nError: {e}")
         else:
-            QMessageBox.warning(
-                self,
-                "Error",
-                f"Build directory not found or invalid:\n{self.build_root}",
-            )
+            QMessageBox.warning(self, "Error", f"Build directory not found or invalid:\n{self.build_root}")
 
     def handle_publish(self):
         selected_store_enum = self.store_type_combo.currentData()
@@ -516,28 +412,21 @@ class PublishProfileEntry(QWidget):
             QMessageBox.warning(self, "Error", "No target platform selected.")
             return
         if self.publish_profile is None:
-            QMessageBox.information(
-                self,
-                "Select Profile",
-                "Create or select a publish profile before publishing.",
-            )
+            QMessageBox.information(self, "Select Profile",
+                                     "Create or select a publish profile before publishing.")
             self.manage_publish_profiles()
             return
 
         publisher_class = self.store_publishers.get(selected_store_enum)
         if not publisher_class:
-            QMessageBox.critical(
-                self, "Error", f"No publisher found for {selected_store_enum.value}"
-            )
+            QMessageBox.critical(self, "Error", f"No publisher found for {selected_store_enum.value}")
             return
 
         try:
             self.validate_build_content()
 
             if selected_store_enum == StoreEnum.steam:
-                publisher_instance = publisher_class(
-                    self.publish_profile
-                )
+                publisher_instance = publisher_class(self.publish_profile)
                 logging.info(f"Attempting to publish build '{self.build_id}' to Steam...")
             else:
                 publisher_instance = publisher_class(self.publish_profile)
@@ -554,28 +443,15 @@ class PublishProfileEntry(QWidget):
             if preflight_dialog.exec() != QDialog.DialogCode.Accepted:
                 return
 
-            publisher_instance.publish(content_dir=self.build_root)
+            publisher_instance.publish(content_dir=self.build_root, version=self.build.version)
 
         except InvalidConfigurationError as e:
-            QMessageBox.warning(
-                self,
-                "Publishing Error",
-                f"Failed to publish '{self.build_id}' to {selected_store_enum.value}:\n\n{str(e)}",
-            )
+            QMessageBox.warning(self, "Publishing Error",
+                                  f"Failed to publish '{self.build_id}' to {selected_store_enum.value}:\n\n{str(e)}")
         except NotImplementedError:
-            QMessageBox.critical(
-                self,
-                "Not Implemented",
-                f"Publishing for {selected_store_enum.value} is not yet implemented.",
-            )
+            QMessageBox.critical(self, "Not Implemented",
+                                   f"Publishing for {selected_store_enum.value} is not yet implemented.")
         except Exception as e:
             logging.info(f"Error during publish execution: {e}")
-            QMessageBox.critical(
-                self,
-                "Publishing Failed",
-                f"An unexpected error occurred while publishing to {selected_store_enum.value}:\n\n{str(e)}",
-            )
-
-    def closeEvent(self, a0):
-        self.session.close()
-        return super().closeEvent(a0)
+            QMessageBox.critical(self, "Publishing Failed",
+                                   f"An unexpected error occurred while publishing to {selected_store_enum.value}:\n\n{str(e)}")


### PR DESCRIPTION
## Summary

- **Add `Build` DB entity** — replaces the loose `build_id` string + `os.listdir` scan. Tracks `version`, `output_path`, `status` (`in_progress` / `success` / `failed`), and `created_at` per build target.
- **Pivot `PublishProfile` FK** from `project_id + build_id` string to `build_target_id`, scoping publish config to a target rather than a project.
- **Namespace output paths** as `archive_dir / project_name / target_name / version` — eliminates path collisions when multiple `BuildTarget`s build the same version string.
- **Replace filesystem scan** in `PublishProfileListWidget` with a DB query (`Build JOIN BuildTarget WHERE project_id = ...`).
- **Multi-target UI** — `BuildTargetListWidget` renders one row per `BuildTarget` instead of hardcoding a single target.
- **SQLite-safe Alembic migration** — uses `batch_alter_table` throughout; includes data backfill for existing rows.
- **Publishers receive `version` param** — `BasePublisher.publish(content_dir, version)` replaces `publish_profile.build_id` reads in Steam and Itch publishers.
